### PR TITLE
docs: remove duplicate Result type definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,8 +326,6 @@ type Tiebreak = (
   players: Player[],
 ) => number;
 
-type Result = 0 | 0.5 | 1;
-
 type PairingSystem = (players: Player[], games: Game[][]) => PairingResult;
 
 interface AccelerationMethod {


### PR DESCRIPTION
## Summary

- removed duplicate `type Result = 0 | 0.5 | 1` from the README types section