### PR TITLE
release: @echecs/tournament@2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.1.2] - 2026-04-17
+
+### Fixed
+
+- Added top-level `types` field to `package.json` for TypeScript configs that
+  don't resolve types through `exports` conditions.
+
 ## 2.1.1 — 2026-04-09
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -77,5 +77,5 @@
     "test:watch": "pnpm run test --watch"
   },
   "type": "module",
-  "version": "2.1.1"
+  "version": "2.1.2"
 }


### PR DESCRIPTION
bumps to 2.1.2. the actual fix (`types` field) is already on `main`. this PR adds the version bump and changelog entry so CI can publish.