### PR TITLE
chore: use explicit glob pattern in lint-staged config

### DIFF
--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  '*': ['prettier --write --ignore-unknown'],
+  '*.(css|js|json|jsx|md|mjs|mts|ts|tsx|yml|yaml)': ['prettier --write'],
   '*.(js|jsx|mjs|mts|ts|tsx)': [
     'eslint --fix --max-warnings 0 --no-warn-ignored',
   ],


### PR DESCRIPTION
replaces `'*': ['prettier --write --ignore-unknown']` with explicit file extension glob `'*.(css|js|json|jsx|md|mjs|mts|ts|tsx|yml|yaml)': ['prettier --write']` to match the canonical form documented in the workspace AGENTS.md.