### PR TITLE
chore: update homepage to echecs.dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "README.md",
     "CHANGELOG.md"
   ],
-  "homepage": "https://github.com/echecsjs/tournament#readme",
+  "homepage": "https://tournament.echecs.dev",
   "keywords": [
     "chess",
     "fide",


### PR DESCRIPTION
points homepage to the docs site instead of the github repo