### PR TITLE
feat!: widen types for trf/swiss integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,28 +91,8 @@ pnpm lint && pnpm test && pnpm build
 
 ## Types
 
-The `Game` type carries an optional `kind?: GameKind` field to classify unplayed
-rounds:
-
-```typescript
-type GameKind =
-  | 'forfeit-loss'
-  | 'forfeit-win'
-  | 'full-bye'
-  | 'half-bye'
-  | 'pairing-bye'
-  | 'zero-bye';
-
-interface Game {
-  black: string;
-  kind?: GameKind;
-  result: Result;
-  white: string;
-}
-```
-
-`Pairing` and `Bye` use `black`/`white`/`player` (plain string ids, not nested
-objects):
+`Game` is a discriminated union extending `Pairing`. Forfeits and byes are
+separate concerns:
 
 ```typescript
 interface Pairing {
@@ -120,10 +100,56 @@ interface Pairing {
   white: string;
 }
 
+type Game = Pairing &
+  (
+    | { forfeit?: never; rated?: boolean; result: 'white' | 'black' | 'draw' }
+    | { forfeit: 'black'; rated?: never; result: 'white' }
+    | { forfeit: 'white'; rated?: never; result: 'black' }
+    | { forfeit: 'both'; rated?: never; result: 'none' }
+  );
+
 interface Bye {
+  kind: 'full' | 'half' | 'pairing' | 'zero';
   player: string;
 }
 ```
+
+`Player` has required `id`, `points`, and `rank`. Optional FIDE metadata:
+
+```typescript
+interface Player {
+  birthDate?: string;
+  federation?: string;
+  fideId?: string;
+  id: string;
+  name?: string;
+  nationalRatings?: NationalRating[];
+  points: number;
+  rank: number;
+  rating?: number;
+  sex?: 'm' | 'w';
+  startingRank?: number;
+  title?: 'CM' | 'FM' | 'GM' | 'IM' | 'WCM' | 'WFM' | 'WGM' | 'WIM';
+}
+```
+
+Rounds evolve: `Pairings` → `Round` → `CompletedRound`:
+
+```typescript
+interface Pairings {
+  byes: Bye[];
+  games: Pairing[];
+}
+interface Round extends Pairings {
+  games: (Pairing | Game)[];
+}
+interface CompletedRound extends Pairings {
+  games: Game[];
+}
+```
+
+`TournamentData` is the serializable plain data interface. `Tournament` is the
+class that wraps it.
 
 `Standing` uses `player` (not `playerId`):
 
@@ -136,26 +162,18 @@ interface Standing {
 }
 ```
 
-## Unified Pairing Interface
-
-All pairing systems consumed by `Tournament` must conform to:
+## Pairing System Signature
 
 ```typescript
-type PairingSystem = (
-  players: Standing[],
-  games: Game[][],
-  options?: object,
-) => { pairings: Pairing[]; byes: Bye[] };
+type PairingSystem = (players: Player[], rounds: CompletedRound[]) => Pairings;
 ```
 
 ## Tiebreak Signature
 
-Tiebreak functions have this signature:
-
 ```typescript
 type Tiebreak = (
-  playerId: string,
-  games: Game[][],
+  player: string,
+  rounds: CompletedRound[],
   players: Player[],
 ) => number;
 ```
@@ -167,9 +185,9 @@ Pass an ordered array of tiebreak functions to
 
 ## Validation
 
-- `RangeError` for: fewer than 2 players, fewer than 1 round, pairing a
-  completed tournament, recording a result for a non-existent pairing, pairing
-  when current round is incomplete.
+- `RangeError` for: pairing a completed tournament, recording a result for a
+  non-existent pairing, pairing when current round is incomplete, entering a
+  duplicate player, withdrawing a non-existent player.
 
 ---
 

--- a/src/__tests__/baku.spec.ts
+++ b/src/__tests__/baku.spec.ts
@@ -7,6 +7,8 @@ import type { Player } from '../types.js';
 function makePlayers(count: number): Player[] {
   return Array.from({ length: count }, (_, index) => ({
     id: String(index + 1),
+    points: 0,
+    rank: index + 1,
   }));
 }
 

--- a/src/__tests__/tournament.spec.ts
+++ b/src/__tests__/tournament.spec.ts
@@ -1,262 +1,178 @@
 import { describe, expect, it } from 'vitest';
 
-import { bakuAcceleration } from '../baku.js';
+import { FIDE_SCORING } from '../scoring.js';
 import { Tournament } from '../tournament.js';
 
 import type {
   Bye,
   Game,
   Pairing,
-  PairingResult,
   PairingSystem,
+  Pairings,
   Player,
   Tiebreak,
+  TournamentData,
 } from '../types.js';
 
 const tiebreakFavorA: Tiebreak = (playerId) => (playerId === 'a' ? 1 : 0);
 const tiebreakConstant: Tiebreak = () => 42;
 
-const mockPairingSystem: PairingSystem = (players) => {
-  const pairings: Pairing[] = [];
+const mockPairingSystem: PairingSystem = (players): Pairings => {
+  const games: Pairing[] = [];
   for (let index = 0; index < players.length - 1; index += 2) {
-    pairings.push({
+    games.push({
       black: players[index + 1]!.id,
       white: players[index]!.id,
     });
   }
   const byes: Bye[] =
-    players.length % 2 === 0 ? [] : [{ player: players.at(-1)!.id }];
-  return { byes, pairings };
+    players.length % 2 === 0
+      ? []
+      : [{ kind: 'pairing', player: players.at(-1)!.id }];
+  return { byes, games };
 };
 
-const players: Player[] = [{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }];
+const players: Player[] = [
+  { id: 'a', points: 0, rank: 1 },
+  { id: 'b', points: 0, rank: 2 },
+  { id: 'c', points: 0, rank: 3 },
+  { id: 'd', points: 0, rank: 4 },
+];
+
+function makeData(overrides?: Partial<TournamentData>): TournamentData {
+  return {
+    completedRounds: [],
+    players: [...players],
+    totalRounds: 3,
+    ...overrides,
+  };
+}
+
+function makeGame(
+  white: string,
+  black: string,
+  result: 'black' | 'draw' | 'white',
+): Game {
+  return { black, result, white };
+}
+
+const byePairingSystem: PairingSystem = (ps): Pairings => {
+  const games: Pairing[] = [];
+  const byes: Bye[] = [];
+  for (let index = 0; index < ps.length - 1; index += 2) {
+    games.push({ black: ps[index + 1]!.id, white: ps[index]!.id });
+  }
+  if (ps.length % 2 !== 0) {
+    byes.push({ kind: 'half', player: ps.at(-1)!.id });
+  }
+  return { byes, games };
+};
+
+/** Helper: pair a round, record all results as white wins, return the tournament. */
+function pairAndRecordRound(t: Tournament): Pairings {
+  const pairings = t.pair();
+  for (const p of pairings.games) {
+    t.record(makeGame(p.white, p.black, 'white'));
+  }
+  return pairings;
+}
 
 describe('Tournament', () => {
   describe('constructor', () => {
-    it('creates a tournament with valid options', () => {
-      const t = new Tournament({
+    it('creates a tournament with valid data', () => {
+      const t = new Tournament(makeData(), {
         pairingSystem: mockPairingSystem,
-        players,
-        rounds: 3,
       });
-      expect(t.rounds).toBe(3);
-      expect(t.players).toHaveLength(4);
-    });
-
-    it('throws RangeError for fewer than 2 players', () => {
-      expect(
-        () =>
-          new Tournament({
-            pairingSystem: mockPairingSystem,
-            players: [{ id: 'a' }],
-            rounds: 1,
-          }),
-      ).toThrow(RangeError);
-    });
-
-    it('throws RangeError for fewer than 1 round', () => {
-      expect(
-        () =>
-          new Tournament({
-            pairingSystem: mockPairingSystem,
-            players,
-            rounds: 0,
-          }),
-      ).toThrow(RangeError);
+      expect(t).toBeInstanceOf(Tournament);
     });
   });
 
-  describe('getters', () => {
-    it('players returns the registered players', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 1,
-      });
-      expect(t.players).toEqual(players);
-    });
-
-    it('rounds returns total round count', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 5,
-      });
-      expect(t.rounds).toBe(5);
-    });
-
-    it('currentRound starts at 0', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 3,
-      });
-      expect(t.currentRound).toBe(0);
-    });
-
-    it('games starts empty', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 3,
-      });
-      expect(t.games).toHaveLength(0);
-    });
-
-    it('isComplete starts as false', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 3,
-      });
-      expect(t.isComplete).toBe(false);
-    });
-
-    it('tiebreaks defaults to empty array', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 3,
-      });
-      expect(t.tiebreaks).toEqual([]);
-    });
-
-    it('tiebreaks returns the configured IDs', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 3,
-        tiebreaks: ['buchholz', 'sonneborn-berger'],
-      });
-      expect(t.tiebreaks).toEqual(['buchholz', 'sonneborn-berger']);
-    });
-
-    it('tiebreaks returns a defensive copy', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 3,
-        tiebreaks: ['buchholz'],
-      });
-      const copy = t.tiebreaks;
-      (copy as string[]).push('extra');
-      expect(t.tiebreaks).toEqual(['buchholz']);
-    });
-  });
-
-  describe('pairRound()', () => {
+  describe('pair()', () => {
     it('returns pairings for round 1', () => {
-      const t = new Tournament({
+      const t = new Tournament(makeData(), {
         pairingSystem: mockPairingSystem,
-        players,
-        rounds: 3,
       });
-      const result = t.pairRound();
-      expect(result.pairings).toHaveLength(2);
+      const result = t.pair();
+      expect(result.games).toHaveLength(2);
       expect(result.byes).toHaveLength(0);
     });
 
-    it('advances currentRound to 1', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 3,
-      });
-      t.pairRound();
-      expect(t.currentRound).toBe(1);
-    });
-
     it('throws RangeError when tournament is complete', () => {
-      const t = new Tournament({
+      const t = new Tournament(makeData({ totalRounds: 1 }), {
         pairingSystem: mockPairingSystem,
-        players,
-        rounds: 1,
       });
-      const result = t.pairRound();
-      for (const pairing of result.pairings) {
-        t.recordResult({
-          black: pairing.black,
-          result: 1,
-          white: pairing.white,
-        });
-      }
-      expect(() => t.pairRound()).toThrow(RangeError);
+      pairAndRecordRound(t);
+      expect(() => t.pair()).toThrow(RangeError);
     });
 
     it('throws RangeError when current round has unrecorded results', () => {
-      const t = new Tournament({
+      const t = new Tournament(makeData(), {
         pairingSystem: mockPairingSystem,
-        players,
-        rounds: 3,
       });
-      t.pairRound();
+      t.pair();
       // Don't record results — pair again should throw
-      expect(() => t.pairRound()).toThrow(RangeError);
+      expect(() => t.pair()).toThrow(RangeError);
     });
   });
 
-  describe('recordResult()', () => {
+  describe('record()', () => {
     it('records a game result', () => {
-      const t = new Tournament({
+      const t = new Tournament(makeData(), {
         pairingSystem: mockPairingSystem,
-        players,
-        rounds: 3,
       });
-      t.pairRound();
-      t.recordResult({ black: 'b', result: 1, white: 'a' });
-      expect(t.games[0]).toHaveLength(1);
+      t.pair();
+      t.record(makeGame('a', 'b', 'white'));
+      // Round should not be auto-completed yet (only 1 of 2 games recorded)
+      const json = t.toJSON();
+      expect(json.currentRound).toBeDefined();
+      expect(json.currentRound!.games).toHaveLength(2);
+    });
+
+    it('auto-completes the round when all results are recorded', () => {
+      const t = new Tournament(makeData(), {
+        pairingSystem: mockPairingSystem,
+      });
+      pairAndRecordRound(t);
+      const json = t.toJSON();
+      expect(json.currentRound).toBeUndefined();
+      expect(json.completedRounds).toHaveLength(1);
     });
 
     it('throws RangeError for a non-existent pairing', () => {
-      const t = new Tournament({
+      const t = new Tournament(makeData(), {
         pairingSystem: mockPairingSystem,
-        players,
-        rounds: 3,
       });
-      t.pairRound();
-      expect(() =>
-        t.recordResult({ black: 'z', result: 1, white: 'x' }),
-      ).toThrow(RangeError);
+      t.pair();
+      expect(() => t.record(makeGame('x', 'z', 'white'))).toThrow(RangeError);
     });
 
     it('throws RangeError when no round has been paired yet', () => {
-      const t = new Tournament({
+      const t = new Tournament(makeData(), {
         pairingSystem: mockPairingSystem,
-        players,
-        rounds: 3,
       });
-      expect(() =>
-        t.recordResult({ black: 'b', result: 1, white: 'a' }),
-      ).toThrow(RangeError);
+      expect(() => t.record(makeGame('a', 'b', 'white'))).toThrow(RangeError);
     });
 
     it('games accumulate across rounds', () => {
-      const t = new Tournament({
+      const t = new Tournament(makeData(), {
         pairingSystem: mockPairingSystem,
-        players,
-        rounds: 3,
       });
+      pairAndRecordRound(t);
+      pairAndRecordRound(t);
 
-      const r1 = t.pairRound();
-      for (const p of r1.pairings) {
-        t.recordResult({ black: p.black, result: 0.5, white: p.white });
-      }
-
-      const r2 = t.pairRound();
-      for (const p of r2.pairings) {
-        t.recordResult({ black: p.black, result: 0.5, white: p.white });
-      }
-
-      expect(t.games.flat()).toHaveLength(4);
+      const json = t.toJSON();
+      const totalGames = json.completedRounds.reduce(
+        (sum, r) => sum + r.games.length,
+        0,
+      );
+      expect(totalGames).toBe(4);
     });
   });
 
   describe('standings()', () => {
-    it('returns empty array when no players (all score 0)', () => {
-      const t = new Tournament({
+    it('returns all players with score 0 before any games', () => {
+      const t = new Tournament(makeData({ totalRounds: 1 }), {
         pairingSystem: mockPairingSystem,
-        players,
-        rounds: 1,
       });
       const s = t.standings();
       expect(s).toHaveLength(4);
@@ -264,16 +180,10 @@ describe('Tournament', () => {
     });
 
     it('computes scores from recorded games', () => {
-      const t = new Tournament({
+      const t = new Tournament(makeData({ totalRounds: 1 }), {
         pairingSystem: mockPairingSystem,
-        players,
-        rounds: 1,
       });
-      const r1 = t.pairRound();
-      // pairings: a vs b, c vs d — white wins each
-      for (const p of r1.pairings) {
-        t.recordResult({ black: p.black, result: 1, white: p.white });
-      }
+      pairAndRecordRound(t);
       const s = t.standings();
       const a = s.find((x) => x.player === 'a')!;
       const b = s.find((x) => x.player === 'b')!;
@@ -282,28 +192,28 @@ describe('Tournament', () => {
     });
 
     it('ranks players by score descending', () => {
-      const t = new Tournament({
+      const t = new Tournament(makeData({ totalRounds: 1 }), {
         pairingSystem: mockPairingSystem,
-        players,
-        rounds: 1,
       });
-      const r1 = t.pairRound();
-      for (const p of r1.pairings) {
-        t.recordResult({ black: p.black, result: 1, white: p.white });
-      }
+      pairAndRecordRound(t);
       const s = t.standings();
       expect(s[0]!.rank).toBe(1);
       expect(s[0]!.score).toBeGreaterThanOrEqual(s[1]!.score);
     });
 
     it('applies tiebreak functions in order', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players: [{ id: 'a' }, { id: 'b' }],
-        rounds: 1,
-      });
-      t.pairRound();
-      t.recordResult({ black: 'b', result: 0.5, white: 'a' });
+      const t = new Tournament(
+        makeData({
+          players: [
+            { id: 'a', points: 0, rank: 1 },
+            { id: 'b', points: 0, rank: 2 },
+          ],
+          totalRounds: 1,
+        }),
+        { pairingSystem: mockPairingSystem },
+      );
+      t.pair();
+      t.record(makeGame('a', 'b', 'draw'));
       // Both have score 0.5; tiebreak returns higher value for 'a'
       const s = t.standings([tiebreakFavorA]);
       expect(s[0]!.player).toBe('a');
@@ -312,798 +222,498 @@ describe('Tournament', () => {
     });
 
     it('assigns same rank to tied players', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players: [{ id: 'a' }, { id: 'b' }],
-        rounds: 1,
-      });
-      t.pairRound();
-      t.recordResult({ black: 'b', result: 0.5, white: 'a' });
-      const s = t.standings(); // no tiebreaks → tied
+      const t = new Tournament(
+        makeData({
+          players: [
+            { id: 'a', points: 0, rank: 1 },
+            { id: 'b', points: 0, rank: 2 },
+          ],
+          totalRounds: 1,
+        }),
+        { pairingSystem: mockPairingSystem },
+      );
+      t.pair();
+      t.record(makeGame('a', 'b', 'draw'));
+      const s = t.standings(); // no tiebreaks - tied
       expect(s[0]!.rank).toBe(1);
       expect(s[1]!.rank).toBe(1);
     });
 
     it('works with no tiebreaks argument', () => {
-      const t = new Tournament({
+      const t = new Tournament(makeData({ totalRounds: 1 }), {
         pairingSystem: mockPairingSystem,
-        players,
-        rounds: 1,
       });
       expect(() => t.standings()).not.toThrow();
       expect(t.standings()).toHaveLength(4);
     });
 
     it('populates tiebreak values in standing entries', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players: [{ id: 'a' }, { id: 'b' }],
-        rounds: 1,
-      });
-      t.pairRound();
-      t.recordResult({ black: 'b', result: 1, white: 'a' });
+      const t = new Tournament(
+        makeData({
+          players: [
+            { id: 'a', points: 0, rank: 1 },
+            { id: 'b', points: 0, rank: 2 },
+          ],
+          totalRounds: 1,
+        }),
+        { pairingSystem: mockPairingSystem },
+      );
+      t.pair();
+      t.record(makeGame('a', 'b', 'white'));
       const s = t.standings([tiebreakConstant]);
       expect(s[0]!.tiebreaks).toEqual([42]);
+    });
+
+    it('includes bye points in standings', () => {
+      const t = new Tournament(
+        makeData({
+          players: [
+            { id: 'a', points: 0, rank: 1 },
+            { id: 'b', points: 0, rank: 2 },
+            { id: 'c', points: 0, rank: 3 },
+          ],
+          totalRounds: 1,
+        }),
+        { pairingSystem: byePairingSystem },
+      );
+      const pairings = t.pair();
+      for (const p of pairings.games) {
+        t.record(makeGame(p.white, p.black, 'draw'));
+      }
+      const s = t.standings();
+      const c = s.find((x) => x.player === 'c')!;
+      expect(c.score).toBe(0.5); // half-bye
+    });
+
+    it('includes point adjustments in standings', () => {
+      const t = new Tournament(
+        makeData({
+          adjustments: [{ playerId: 'a', points: -0.5, round: 0 }],
+          totalRounds: 1,
+        }),
+        { pairingSystem: mockPairingSystem },
+      );
+      pairAndRecordRound(t);
+      const s = t.standings();
+      const a = s.find((x) => x.player === 'a')!;
+      expect(a.score).toBe(0.5); // 1 (win) - 0.5 (adjustment)
+    });
+  });
+
+  describe('correct()', () => {
+    it('corrects a result in a completed round', () => {
+      const t = new Tournament(makeData({ totalRounds: 2 }), {
+        pairingSystem: mockPairingSystem,
+      });
+      pairAndRecordRound(t);
+      pairAndRecordRound(t);
+      // Correct round 1 result
+      t.correct(1, makeGame('a', 'b', 'black'));
+      const json = t.toJSON();
+      const game = json.completedRounds[0]!.games.find(
+        (g) => g.white === 'a' && g.black === 'b',
+      );
+      expect(game!.result).toBe('black');
+    });
+
+    it('logs a comment on correction', () => {
+      const t = new Tournament(makeData({ totalRounds: 1 }), {
+        pairingSystem: mockPairingSystem,
+      });
+      pairAndRecordRound(t);
+      t.correct(1, makeGame('a', 'b', 'draw'));
+      const json = t.toJSON();
+      expect(json.metadata?.comments).toBeDefined();
+      expect(json.metadata!.comments!.length).toBeGreaterThan(0);
+    });
+
+    it('throws RangeError for invalid round', () => {
+      const t = new Tournament(makeData({ totalRounds: 1 }), {
+        pairingSystem: mockPairingSystem,
+      });
+      pairAndRecordRound(t);
+      expect(() => t.correct(0, makeGame('a', 'b', 'draw'))).toThrow(
+        RangeError,
+      );
+    });
+
+    it('throws RangeError for non-existent pairing', () => {
+      const t = new Tournament(makeData({ totalRounds: 1 }), {
+        pairingSystem: mockPairingSystem,
+      });
+      pairAndRecordRound(t);
+      expect(() => t.correct(1, makeGame('x', 'y', 'draw'))).toThrow(
+        RangeError,
+      );
+    });
+
+    it('standings reflect the corrected result', () => {
+      const t = new Tournament(
+        makeData({
+          players: [
+            { id: 'a', points: 0, rank: 1 },
+            { id: 'b', points: 0, rank: 2 },
+          ],
+          totalRounds: 1,
+        }),
+        { pairingSystem: mockPairingSystem },
+      );
+      t.pair();
+      t.record(makeGame('a', 'b', 'white')); // a wins
+      expect(t.standings().find((s) => s.player === 'a')!.score).toBe(1);
+
+      t.correct(1, makeGame('a', 'b', 'black')); // change to b wins
+      expect(t.standings().find((s) => s.player === 'a')!.score).toBe(0);
+      expect(t.standings().find((s) => s.player === 'b')!.score).toBe(1);
+    });
+  });
+
+  describe('clear()', () => {
+    it('clears a result in a completed round', () => {
+      const t = new Tournament(makeData({ totalRounds: 1 }), {
+        pairingSystem: mockPairingSystem,
+      });
+      pairAndRecordRound(t);
+      t.clear(1, 'a', 'b');
+      const json = t.toJSON();
+      const game = json.completedRounds[0]!.games.find(
+        (g) => g.white === 'a' && g.black === 'b',
+      );
+      // Should be reverted to a pairing (no result)
+      expect(game).toBeDefined();
+      expect('result' in game! && typeof game!.result === 'string').toBe(false);
+    });
+
+    it('throws RangeError for round 0', () => {
+      const t = new Tournament(makeData({ totalRounds: 1 }), {
+        pairingSystem: mockPairingSystem,
+      });
+      pairAndRecordRound(t);
+      expect(() => t.clear(0, 'a', 'b')).toThrow(RangeError);
+    });
+
+    it('throws RangeError for invalid round', () => {
+      const t = new Tournament(makeData({ totalRounds: 1 }), {
+        pairingSystem: mockPairingSystem,
+      });
+      pairAndRecordRound(t);
+      expect(() => t.clear(5, 'a', 'b')).toThrow(RangeError);
+    });
+  });
+
+  describe('enter()', () => {
+    it('adds a new player', () => {
+      const t = new Tournament(makeData(), {
+        pairingSystem: mockPairingSystem,
+      });
+      t.enter({ id: 'e', points: 0, rank: 5 });
+      const json = t.toJSON();
+      expect(json.players).toHaveLength(5);
+      expect(json.players.find((p) => p.id === 'e')).toBeDefined();
+    });
+
+    it('logs a comment on late entry', () => {
+      const t = new Tournament(makeData(), {
+        pairingSystem: mockPairingSystem,
+      });
+      t.enter({ id: 'e', points: 0, rank: 5 });
+      const json = t.toJSON();
+      expect(json.metadata?.comments).toBeDefined();
+      expect(
+        json.metadata!.comments!.some((c) => c.includes('late entry')),
+      ).toBe(true);
+    });
+
+    it('throws RangeError for duplicate player', () => {
+      const t = new Tournament(makeData(), {
+        pairingSystem: mockPairingSystem,
+      });
+      expect(() => t.enter({ id: 'a', points: 0, rank: 5 })).toThrow(
+        RangeError,
+      );
+    });
+  });
+
+  describe('withdraw()', () => {
+    it('removes a player', () => {
+      const t = new Tournament(makeData(), {
+        pairingSystem: mockPairingSystem,
+      });
+      t.withdraw('d');
+      const json = t.toJSON();
+      expect(json.players).toHaveLength(3);
+      expect(json.players.find((p) => p.id === 'd')).toBeUndefined();
+    });
+
+    it('throws RangeError for non-existent player', () => {
+      const t = new Tournament(makeData(), {
+        pairingSystem: mockPairingSystem,
+      });
+      expect(() => t.withdraw('z')).toThrow(RangeError);
+    });
+  });
+
+  describe('adjust()', () => {
+    it('adds a point adjustment', () => {
+      const t = new Tournament(makeData(), {
+        pairingSystem: mockPairingSystem,
+      });
+      t.adjust({ playerId: 'a', points: -1, round: 0 });
+      const json = t.toJSON();
+      expect(json.adjustments).toHaveLength(1);
+      expect(json.adjustments![0]!.points).toBe(-1);
+    });
+
+    it('logs a comment on adjustment', () => {
+      const t = new Tournament(makeData(), {
+        pairingSystem: mockPairingSystem,
+      });
+      t.adjust({ playerId: 'a', points: -1, reason: 'late', round: 1 });
+      const json = t.toJSON();
+      expect(json.metadata?.comments).toBeDefined();
+      expect(
+        json.metadata!.comments!.some((c) => c.includes('point adjustment')),
+      ).toBe(true);
     });
   });
 
   describe('serialization', () => {
     it('toJSON returns a plain serializable object', () => {
-      const t = new Tournament({
+      const t = new Tournament(makeData({ totalRounds: 2 }), {
         pairingSystem: mockPairingSystem,
-        players,
-        rounds: 2,
       });
-      const r1 = t.pairRound();
-      for (const p of r1.pairings) {
-        t.recordResult({ black: p.black, result: 1, white: p.white });
-      }
+      pairAndRecordRound(t);
       const json = t.toJSON();
-      expect(json.currentRound).toBe(1);
-      expect(json.games.flat()).toHaveLength(2);
-      expect(json.rounds).toBe(2);
+      expect(json.completedRounds).toHaveLength(1);
+      expect(json.completedRounds[0]!.games).toHaveLength(2);
+      expect(json.totalRounds).toBe(2);
       // eslint-disable-next-line unicorn/prefer-structured-clone
       expect(JSON.parse(JSON.stringify(json))).toEqual(json);
     });
 
     it('fromJSON restores tournament state', () => {
-      const t = new Tournament({
+      const t = new Tournament(makeData({ totalRounds: 2 }), {
         pairingSystem: mockPairingSystem,
-        players,
-        rounds: 2,
       });
-      const r1 = t.pairRound();
-      for (const p of r1.pairings) {
-        t.recordResult({ black: p.black, result: 1, white: p.white });
-      }
+      pairAndRecordRound(t);
       const json = t.toJSON();
-      const restored = Tournament.fromJSON(json, mockPairingSystem);
-      expect(restored.currentRound).toBe(t.currentRound);
-      expect(restored.games).toEqual(t.games);
-      expect(restored.rounds).toBe(t.rounds);
-      expect(restored.players).toEqual(t.players);
+      const restored = Tournament.fromJSON(json, {
+        pairingSystem: mockPairingSystem,
+      });
+      expect(restored.toJSON()).toEqual(json);
     });
 
     it('restored tournament can continue pairing', () => {
-      const t = new Tournament({
+      const t = new Tournament(makeData({ totalRounds: 2 }), {
         pairingSystem: mockPairingSystem,
-        players,
-        rounds: 2,
       });
-      const r1 = t.pairRound();
-      for (const p of r1.pairings) {
-        t.recordResult({ black: p.black, result: 1, white: p.white });
-      }
-      const restored = Tournament.fromJSON(t.toJSON(), mockPairingSystem);
-      expect(() => restored.pairRound()).not.toThrow();
-      expect(restored.currentRound).toBe(2);
+      pairAndRecordRound(t);
+      const restored = Tournament.fromJSON(t.toJSON(), {
+        pairingSystem: mockPairingSystem,
+      });
+      expect(() => restored.pair()).not.toThrow();
     });
 
     it('round-trips preserve all state', () => {
-      const t = new Tournament({
+      const t = new Tournament(makeData({ totalRounds: 2 }), {
         pairingSystem: mockPairingSystem,
-        players,
-        rounds: 2,
       });
-      const r1 = t.pairRound();
-      for (const p of r1.pairings) {
-        t.recordResult({ black: p.black, result: 0.5, white: p.white });
-      }
+      pairAndRecordRound(t);
       const snap1 = t.toJSON();
-      const restored = Tournament.fromJSON(snap1, mockPairingSystem);
+      const restored = Tournament.fromJSON(snap1, {
+        pairingSystem: mockPairingSystem,
+      });
       const snap2 = restored.toJSON();
       expect(snap2).toEqual(snap1);
     });
 
     it('toJSON includes tiebreaks when configured', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 2,
-        tiebreaks: ['buchholz', 'sonneborn-berger'],
-      });
+      const t = new Tournament(
+        makeData({
+          tiebreaks: ['buchholz', 'sonneborn-berger'],
+          totalRounds: 2,
+        }),
+        { pairingSystem: mockPairingSystem },
+      );
       const json = t.toJSON();
       expect(json.tiebreaks).toEqual(['buchholz', 'sonneborn-berger']);
     });
 
-    it('toJSON omits tiebreaks when empty', () => {
-      const t = new Tournament({
+    it('serialization round-trip preserves corrected results', () => {
+      const t = new Tournament(makeData({ totalRounds: 2 }), {
         pairingSystem: mockPairingSystem,
-        players,
-        rounds: 2,
       });
-      const json = t.toJSON();
-      expect(json.tiebreaks).toBeUndefined();
-    });
+      pairAndRecordRound(t);
+      t.correct(1, makeGame('a', 'b', 'black'));
 
-    it('fromJSON restores tiebreak IDs', () => {
-      const t = new Tournament({
+      const snap = t.toJSON();
+      const restored = Tournament.fromJSON(snap, {
         pairingSystem: mockPairingSystem,
-        players,
-        rounds: 2,
-        tiebreaks: ['buchholz'],
       });
-      const restored = Tournament.fromJSON(t.toJSON(), mockPairingSystem);
-      expect(restored.tiebreaks).toEqual(['buchholz']);
-    });
-
-    it('fromJSON handles snapshots without tiebreaks', () => {
-      const snapshot = {
-        currentRound: 0,
-        games: [],
-        players,
-        roundPairings: {},
-        rounds: 2,
-      };
-      const restored = Tournament.fromJSON(snapshot, mockPairingSystem);
-      expect(restored.tiebreaks).toEqual([]);
+      const restoredGame = restored
+        .toJSON()
+        .completedRounds[0]!.games.find(
+          (g) => g.white === 'a' && g.black === 'b',
+        );
+      expect(restoredGame!.result).toBe('black');
     });
   });
 
-  describe('acceleration integration', () => {
-    it('virtual points affect pairing system input but not stored games', () => {
-      const acceleratedPlayers: Player[] = [
-        { id: 'a' },
-        { id: 'b' },
-        { id: 'c' },
-        { id: 'd' },
-      ];
-      // gaSize = 2 * ceil(4/4) = 2 → GA = [a, b], GB = [c, d]
-      const acceleration = bakuAcceleration(acceleratedPlayers);
-
-      let capturedGames: Game[][] = [];
-      const spyPairingSystem: PairingSystem = (
-        spyPlayers,
-        games,
-      ): PairingResult => {
-        capturedGames = [...games];
-        const pairings: Pairing[] = [];
-        for (let index = 0; index < spyPlayers.length - 1; index += 2) {
-          pairings.push({
-            black: spyPlayers[index + 1]!.id,
-            white: spyPlayers[index]!.id,
-          });
-        }
-        return { byes: [], pairings };
-      };
-
-      const t = new Tournament({
-        acceleration,
-        pairingSystem: spyPairingSystem,
-        players: acceleratedPlayers,
-        rounds: 9,
+  describe('Game type', () => {
+    it('accepts a played game with rated flag', () => {
+      const t = new Tournament(makeData({ totalRounds: 1 }), {
+        pairingSystem: mockPairingSystem,
       });
-
-      t.pairRound();
-
-      // Virtual games are prepended as extra round (index 0)
-      const virtualGames = capturedGames[0] ?? [];
-      expect(virtualGames.length).toBeGreaterThan(0);
-
-      // GA players (a, b) each have a virtual game with 1 virtual point (round 1 of 9)
-      const virtualForA = virtualGames.find((g) => g.white === 'a');
-      expect(virtualForA).toBeDefined();
-      expect(virtualForA?.result).toBe(1);
-
-      // GB players (c, d) have no virtual games
-      expect(virtualGames.some((g) => g.white === 'c')).toBe(false);
-      expect(virtualGames.some((g) => g.white === 'd')).toBe(false);
-
-      // tournament.games does NOT contain virtual games — round array is empty
-      expect(t.games.flat()).toHaveLength(0);
+      t.pair();
+      expect(() =>
+        t.record({ black: 'b', rated: true, result: 'white', white: 'a' }),
+      ).not.toThrow();
     });
 
-    it('works end-to-end with acceleration', () => {
-      const acceleratedPlayers: Player[] = [
-        { id: 'a' },
-        { id: 'b' },
-        { id: 'c' },
-        { id: 'd' },
-      ];
-      const acceleration = bakuAcceleration(acceleratedPlayers);
-
-      const t = new Tournament({
-        acceleration,
+    it('accepts forfeit game', () => {
+      const t = new Tournament(makeData({ totalRounds: 1 }), {
         pairingSystem: mockPairingSystem,
-        players: acceleratedPlayers,
-        rounds: 3,
       });
+      t.pair();
+      expect(() =>
+        t.record({
+          black: 'b',
+          forfeit: 'black',
+          result: 'white',
+          white: 'a',
+        }),
+      ).not.toThrow();
+    });
 
-      // Pair and record all 3 rounds
-      for (let round = 0; round < 3; round++) {
-        const result = t.pairRound();
-        for (const p of result.pairings) {
-          t.recordResult({ black: p.black, result: 1, white: p.white });
-        }
-      }
+    it('accepts double forfeit', () => {
+      const t = new Tournament(makeData({ totalRounds: 1 }), {
+        pairingSystem: mockPairingSystem,
+      });
+      t.pair();
+      expect(() =>
+        t.record({
+          black: 'b',
+          forfeit: 'both',
+          result: 'none',
+          white: 'a',
+        }),
+      ).not.toThrow();
+    });
+  });
 
-      expect(t.isComplete).toBe(true);
-      expect(t.currentRound).toBe(3);
-
+  describe('ScoringSystem', () => {
+    it('uses custom scoring system', () => {
+      const t = new Tournament(
+        makeData({
+          players: [
+            { id: 'a', points: 0, rank: 1 },
+            { id: 'b', points: 0, rank: 2 },
+          ],
+          scoringSystem: { draw: 0.3, loss: 0, win: 3 },
+          totalRounds: 1,
+        }),
+        { pairingSystem: mockPairingSystem },
+      );
+      t.pair();
+      t.record(makeGame('a', 'b', 'white'));
       const s = t.standings();
-      expect(s).toHaveLength(4);
-      // All scores should be non-negative and sum correctly
-      const totalScore = s.reduce((sum, entry) => sum + entry.score, 0);
-      // 3 rounds × 2 games per round × 1 point per game = 6 total points
-      expect(totalScore).toBe(6);
+      expect(s.find((x) => x.player === 'a')!.score).toBe(3);
+      expect(s.find((x) => x.player === 'b')!.score).toBe(0);
+    });
 
-      // Games stored are only real games (no virtual)
-      expect(t.games.flat()).toHaveLength(6);
+    it('uses FIDE defaults when no scoring system specified', () => {
+      const t = new Tournament(
+        makeData({
+          players: [
+            { id: 'a', points: 0, rank: 1 },
+            { id: 'b', points: 0, rank: 2 },
+          ],
+          totalRounds: 1,
+        }),
+        { pairingSystem: mockPairingSystem },
+      );
+      t.pair();
+      t.record(makeGame('a', 'b', 'draw'));
+      const s = t.standings();
+      expect(s.find((x) => x.player === 'a')!.score).toBe(0.5);
+      expect(s.find((x) => x.player === 'b')!.score).toBe(0.5);
     });
   });
 
-  describe('updateResult()', () => {
-    it('replaces a result in the current round', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 3,
-      });
-      const r1 = t.pairRound();
-      // Record white wins
-      for (const p of r1.pairings) {
-        t.recordResult({ black: p.black, result: 1, white: p.white });
-      }
-      // Update first pairing to a draw
-      const first = r1.pairings[0]!;
-      t.updateResult(1, {
-        black: first.black,
-        result: 0.5,
-        white: first.white,
-      });
-      const updatedGame = t.games[0]!.find(
-        (g) => g.white === first.white && g.black === first.black,
-      );
-      expect(updatedGame!.result).toBe(0.5);
-      // Total game count unchanged (replaced, not appended)
-      expect(t.games[0]).toHaveLength(2);
-    });
-
-    it('replaces a result in a past round', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 3,
-      });
-      // Complete round 1
-      const r1 = t.pairRound();
-      for (const p of r1.pairings) {
-        t.recordResult({ black: p.black, result: 1, white: p.white });
-      }
-      // Complete round 2
-      const r2 = t.pairRound();
-      for (const p of r2.pairings) {
-        t.recordResult({ black: p.black, result: 1, white: p.white });
-      }
-      // Update round 1 result
-      const first = r1.pairings[0]!;
-      t.updateResult(1, { black: first.black, result: 0, white: first.white });
-      const updatedGame = t.games[0]!.find(
-        (g) => g.white === first.white && g.black === first.black,
-      );
-      expect(updatedGame!.result).toBe(0);
-    });
-
-    it('finds the game when white/black are swapped in input', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 3,
-      });
-      const r1 = t.pairRound();
-      for (const p of r1.pairings) {
-        t.recordResult({ black: p.black, result: 1, white: p.white });
-      }
-      // Update with swapped colors — should still find the game
-      const first = r1.pairings[0]!;
-      t.updateResult(1, {
-        black: first.white,
-        result: 0,
-        white: first.black,
-      });
-      // The stored game retains its original color assignment
-      const updatedGame = t.games[0]!.find(
-        (g) => g.white === first.white && g.black === first.black,
-      );
-      expect(updatedGame).toBeDefined();
-      expect(updatedGame!.result).toBe(0);
-    });
-
-    it('updates the kind field', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 3,
-      });
-      const r1 = t.pairRound();
-      for (const p of r1.pairings) {
-        t.recordResult({ black: p.black, result: 1, white: p.white });
-      }
-      const first = r1.pairings[0]!;
-      t.updateResult(1, {
-        black: first.black,
-        kind: 'forfeit-win',
-        result: 1,
-        white: first.white,
-      });
-      const updatedGame = t.games[0]!.find(
-        (g) => g.white === first.white && g.black === first.black,
-      );
-      expect(updatedGame!.kind).toBe('forfeit-win');
-    });
-
-    it('throws RangeError for round 0', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 3,
-      });
-      t.pairRound();
-      t.recordResult({ black: 'b', result: 1, white: 'a' });
-      expect(() =>
-        t.updateResult(0, { black: 'b', result: 0.5, white: 'a' }),
-      ).toThrow(RangeError);
-    });
-
-    it('throws RangeError for round beyond currentRound', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 3,
-      });
-      t.pairRound();
-      t.recordResult({ black: 'b', result: 1, white: 'a' });
-      expect(() =>
-        t.updateResult(2, { black: 'b', result: 0.5, white: 'a' }),
-      ).toThrow(RangeError);
-    });
-
-    it('throws RangeError when no result exists for the pairing', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 3,
-      });
-      const r1 = t.pairRound();
-      // Only record one of two pairings
-      const first = r1.pairings[0]!;
-      t.recordResult({ black: first.black, result: 1, white: first.white });
-      // Try to update the unrecorded pairing
-      const second = r1.pairings[1]!;
-      expect(() =>
-        t.updateResult(1, {
-          black: second.black,
-          result: 0.5,
-          white: second.white,
-        }),
-      ).toThrow(RangeError);
-    });
-
-    it('standings reflect the updated result', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players: [{ id: 'a' }, { id: 'b' }],
-        rounds: 1,
-      });
-      t.pairRound();
-      t.recordResult({ black: 'b', result: 1, white: 'a' }); // a wins
-      expect(t.standings().find((s) => s.player === 'a')!.score).toBe(1);
-
-      t.updateResult(1, { black: 'b', result: 0, white: 'a' }); // change to b wins
-      expect(t.standings().find((s) => s.player === 'a')!.score).toBe(0);
-      expect(t.standings().find((s) => s.player === 'b')!.score).toBe(1);
-    });
-
-    it('serialization round-trip preserves updated results', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 2,
-      });
-      const r1 = t.pairRound();
-      for (const p of r1.pairings) {
-        t.recordResult({ black: p.black, result: 1, white: p.white });
-      }
-      const first = r1.pairings[0]!;
-      t.updateResult(1, { black: first.black, result: 0, white: first.white });
-
-      const snap = t.toJSON();
-      const restored = Tournament.fromJSON(snap, mockPairingSystem);
-      const restoredGame = restored.games[0]!.find(
-        (g) => g.white === first.white && g.black === first.black,
-      );
-      expect(restoredGame!.result).toBe(0);
-    });
-  });
-
-  describe('clearResult()', () => {
-    it('removes a result from the current round', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 3,
-      });
-      const r1 = t.pairRound();
-      for (const p of r1.pairings) {
-        t.recordResult({ black: p.black, result: 1, white: p.white });
-      }
-      expect(t.games[0]).toHaveLength(2);
-      const first = r1.pairings[0]!;
-      t.clearResult(1, first.white, first.black);
-      expect(t.games[0]).toHaveLength(1);
-    });
-
-    it('removes a result from a past round', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 3,
-      });
-      const r1 = t.pairRound();
-      for (const p of r1.pairings) {
-        t.recordResult({ black: p.black, result: 1, white: p.white });
-      }
-      const r2 = t.pairRound();
-      for (const p of r2.pairings) {
-        t.recordResult({ black: p.black, result: 1, white: p.white });
-      }
-      expect(t.games[0]).toHaveLength(2);
-      const first = r1.pairings[0]!;
-      t.clearResult(1, first.white, first.black);
-      expect(t.games[0]).toHaveLength(1);
-    });
-
-    it('finds the game when white/black are swapped in input', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 3,
-      });
-      const r1 = t.pairRound();
-      for (const p of r1.pairings) {
-        t.recordResult({ black: p.black, result: 1, white: p.white });
-      }
-      const first = r1.pairings[0]!;
-      // Pass black as white and vice versa — should still find the game
-      t.clearResult(1, first.black, first.white);
-      expect(t.games[0]).toHaveLength(1);
-    });
-
-    it('throws RangeError for round 0', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 3,
-      });
-      t.pairRound();
-      t.recordResult({ black: 'b', result: 1, white: 'a' });
-      expect(() => t.clearResult(0, 'a', 'b')).toThrow(RangeError);
-    });
-
-    it('throws RangeError for round beyond currentRound', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 3,
-      });
-      t.pairRound();
-      t.recordResult({ black: 'b', result: 1, white: 'a' });
-      expect(() => t.clearResult(2, 'a', 'b')).toThrow(RangeError);
-    });
-
-    it('throws RangeError when no result exists for the pairing', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 3,
-      });
-      const r1 = t.pairRound();
-      const first = r1.pairings[0]!;
-      t.recordResult({ black: first.black, result: 1, white: first.white });
-      // Try to clear the unrecorded second pairing
-      const second = r1.pairings[1]!;
-      expect(() => t.clearResult(1, second.white, second.black)).toThrow(
-        RangeError,
-      );
-    });
-
-    it('allows re-recording a cleared result via recordResult', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players: [{ id: 'a' }, { id: 'b' }],
-        rounds: 1,
-      });
-      t.pairRound();
-      t.recordResult({ black: 'b', result: 1, white: 'a' });
-      t.clearResult(1, 'a', 'b');
-      expect(t.games[0]).toHaveLength(0);
-      // Re-record with a different result
-      t.recordResult({ black: 'b', result: 0, white: 'a' });
-      expect(t.games[0]).toHaveLength(1);
-      expect(t.games[0]![0]!.result).toBe(0);
-    });
-
-    it('standings reflect the cleared result', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players: [{ id: 'a' }, { id: 'b' }],
-        rounds: 1,
-      });
-      t.pairRound();
-      t.recordResult({ black: 'b', result: 1, white: 'a' }); // a wins
-      expect(t.standings().find((s) => s.player === 'a')!.score).toBe(1);
-
-      t.clearResult(1, 'a', 'b');
-      // After clearing, both players should have 0 score
-      expect(t.standings().find((s) => s.player === 'a')!.score).toBe(0);
-      expect(t.standings().find((s) => s.player === 'b')!.score).toBe(0);
-    });
-
-    it('serialization round-trip preserves cleared state', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 2,
-      });
-      const r1 = t.pairRound();
-      for (const p of r1.pairings) {
-        t.recordResult({ black: p.black, result: 1, white: p.white });
-      }
-      const first = r1.pairings[0]!;
-      t.clearResult(1, first.white, first.black);
-
-      const snap = t.toJSON();
-      const restored = Tournament.fromJSON(snap, mockPairingSystem);
-      expect(restored.games[0]).toHaveLength(1);
-    });
-  });
-
-  describe('GameKind validation', () => {
-    it('accepts forfeit-win with result 1', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 1,
-      });
-      t.pairRound();
-      expect(() =>
-        t.recordResult({
-          black: 'b',
-          kind: 'forfeit-win',
-          result: 1,
-          white: 'a',
-        }),
-      ).not.toThrow();
-    });
-
-    it('throws for forfeit-win with result 0', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 1,
-      });
-      t.pairRound();
-      expect(() =>
-        t.recordResult({
-          black: 'b',
-          kind: 'forfeit-win',
-          result: 0,
-          white: 'a',
-        }),
-      ).toThrow(RangeError);
-    });
-
-    it('throws for forfeit-loss with result 1', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 1,
-      });
-      t.pairRound();
-      expect(() =>
-        t.recordResult({
-          black: 'b',
-          kind: 'forfeit-loss',
-          result: 1,
-          white: 'a',
-        }),
-      ).toThrow(RangeError);
-    });
-
-    it('accepts forfeit-loss with result 0', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 1,
-      });
-      t.pairRound();
-      expect(() =>
-        t.recordResult({
-          black: 'b',
-          kind: 'forfeit-loss',
-          result: 0,
-          white: 'a',
-        }),
-      ).not.toThrow();
-    });
-
-    it('accepts half-bye with result 0.5', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 1,
-      });
-      t.pairRound();
-      expect(() =>
-        t.recordResult({
-          black: 'b',
-          kind: 'half-bye',
-          result: 0.5,
-          white: 'a',
-        }),
-      ).not.toThrow();
-    });
-
-    it('throws for half-bye with result 1', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 1,
-      });
-      t.pairRound();
-      expect(() =>
-        t.recordResult({
-          black: 'b',
-          kind: 'half-bye',
-          result: 1,
-          white: 'a',
-        }),
-      ).toThrow(RangeError);
-    });
-
-    it('throws for pairing-bye with result 0', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 1,
-      });
-      t.pairRound();
-      expect(() =>
-        t.recordResult({
-          black: 'b',
-          kind: 'pairing-bye',
-          result: 0,
-          white: 'a',
-        }),
-      ).toThrow(RangeError);
-    });
-
-    it('throws for zero-bye with result 1', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 1,
-      });
-      t.pairRound();
-      expect(() =>
-        t.recordResult({
-          black: 'b',
-          kind: 'zero-bye',
-          result: 1,
-          white: 'a',
-        }),
-      ).toThrow(RangeError);
-    });
-
-    it('throws for full-bye with result 0.5', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 1,
-      });
-      t.pairRound();
-      expect(() =>
-        t.recordResult({
-          black: 'b',
-          kind: 'full-bye',
-          result: 0.5,
-          white: 'a',
-        }),
-      ).toThrow(RangeError);
-    });
-
-    it('updateResult also validates kind/result consistency', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 1,
-      });
-      t.pairRound();
-      t.recordResult({ black: 'b', result: 1, white: 'a' });
-      expect(() =>
-        t.updateResult(1, {
-          black: 'b',
-          kind: 'forfeit-win',
-          result: 0,
-          white: 'a',
-        }),
-      ).toThrow(RangeError);
-    });
-
-    it('no validation when kind is omitted', () => {
-      const t = new Tournament({
-        pairingSystem: mockPairingSystem,
-        players,
-        rounds: 1,
-      });
-      t.pairRound();
-      expect(() =>
-        t.recordResult({ black: 'b', result: 0.5, white: 'a' }),
-      ).not.toThrow();
+  describe('FIDE_SCORING', () => {
+    it('exports FIDE default values', () => {
+      expect(FIDE_SCORING.win).toBe(1);
+      expect(FIDE_SCORING.draw).toBe(0.5);
+      expect(FIDE_SCORING.loss).toBe(0);
+      expect(FIDE_SCORING.forfeitWin).toBe(1);
+      expect(FIDE_SCORING.forfeitLoss).toBe(0);
+      expect(FIDE_SCORING.fullPointBye).toBe(1);
+      expect(FIDE_SCORING.halfPointBye).toBe(0.5);
+      expect(FIDE_SCORING.pairingAllocatedBye).toBe(1);
+      expect(FIDE_SCORING.zeroPointBye).toBe(0);
+      expect(FIDE_SCORING.absence).toBe(0);
     });
   });
 
   describe('full lifecycle', () => {
-    it('completes a 1-round tournament and reports isComplete', () => {
-      const t = new Tournament({
+    it('completes a 1-round tournament', () => {
+      const t = new Tournament(makeData({ totalRounds: 1 }), {
         pairingSystem: mockPairingSystem,
-        players,
-        rounds: 1,
       });
-
-      expect(t.isComplete).toBe(false);
-
-      const r1 = t.pairRound();
-      expect(t.currentRound).toBe(1);
-      expect(t.isComplete).toBe(false);
-
-      for (const p of r1.pairings) {
-        t.recordResult({ black: p.black, result: 1, white: p.white });
-      }
-
-      expect(t.isComplete).toBe(true);
+      pairAndRecordRound(t);
+      const json = t.toJSON();
+      expect(json.completedRounds).toHaveLength(1);
+      expect(json.currentRound).toBeUndefined();
     });
 
-    it('completes a 2-round tournament pair→record→pair→record→isComplete', () => {
-      const t = new Tournament({
+    it('completes a 2-round tournament pair-record-pair-record', () => {
+      const t = new Tournament(makeData({ totalRounds: 2 }), {
         pairingSystem: mockPairingSystem,
-        players,
-        rounds: 2,
       });
+      pairAndRecordRound(t);
+      pairAndRecordRound(t);
 
-      const r1 = t.pairRound();
-      for (const p of r1.pairings) {
-        t.recordResult({ black: p.black, result: 1, white: p.white });
-      }
-      expect(t.isComplete).toBe(false);
+      const json = t.toJSON();
+      expect(json.completedRounds).toHaveLength(2);
+      expect(json.currentRound).toBeUndefined();
 
-      const r2 = t.pairRound();
-      for (const p of r2.pairings) {
-        t.recordResult({ black: p.black, result: 1, white: p.white });
-      }
+      const s = t.standings();
+      expect(s).toHaveLength(4);
+      // 2 rounds x 2 games x 1 point per game = 4 total points
+      const totalScore = s.reduce((sum, entry) => sum + entry.score, 0);
+      expect(totalScore).toBe(4);
+    });
 
-      expect(t.currentRound).toBe(2);
-      expect(t.isComplete).toBe(true);
+    it('supports late entry mid-tournament', () => {
+      const t = new Tournament(makeData({ totalRounds: 3 }), {
+        pairingSystem: mockPairingSystem,
+      });
+      pairAndRecordRound(t);
+      t.enter({ id: 'e', points: 0, rank: 5 });
+      // Should be able to pair with 5 players now
+      const r2 = t.pair();
+      expect(r2.games.length + r2.byes.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('supports withdrawal mid-tournament', () => {
+      const t = new Tournament(
+        makeData({
+          players: [
+            { id: 'a', points: 0, rank: 1 },
+            { id: 'b', points: 0, rank: 2 },
+            { id: 'c', points: 0, rank: 3 },
+            { id: 'd', points: 0, rank: 4 },
+            { id: 'e', points: 0, rank: 5 },
+            { id: 'f', points: 0, rank: 6 },
+          ],
+          totalRounds: 3,
+        }),
+        { pairingSystem: mockPairingSystem },
+      );
+      pairAndRecordRound(t);
+      t.withdraw('f');
+      const json = t.toJSON();
+      expect(json.players).toHaveLength(5);
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,25 @@
 export { bakuAcceleration } from './baku.js';
+export { FIDE_SCORING } from './scoring.js';
 export { Tournament } from './tournament.js';
 export type {
   AccelerationMethod,
+  AcceleratedRound,
   Bye,
+  CompletedRound,
   Game,
-  GameKind,
+  NationalRating,
   Pairing,
-  PairingResult,
   PairingSystem,
+  Pairings,
   Player,
-  Result,
+  PlayerAcceleration,
+  PointAdjustment,
+  ProhibitedPairing,
+  Round,
+  ScoringSystem,
   Standing,
+  Team,
   Tiebreak,
-  TournamentOptions,
-  TournamentSnapshot,
+  TournamentData,
+  TournamentMetadata,
 } from './types.js';

--- a/src/scoring.ts
+++ b/src/scoring.ts
@@ -1,0 +1,20 @@
+import type { ScoringSystem } from './types.js';
+
+/**
+ * Default FIDE scoring system. Color-specific values are omitted — consumers
+ * fall back to the base values (e.g. `whiteWin ?? win ?? 1`).
+ */
+const FIDE_SCORING: ScoringSystem = {
+  absence: 0,
+  draw: 0.5,
+  forfeitLoss: 0,
+  forfeitWin: 1,
+  fullPointBye: 1,
+  halfPointBye: 0.5,
+  loss: 0,
+  pairingAllocatedBye: 1,
+  win: 1,
+  zeroPointBye: 0,
+};
+
+export { FIDE_SCORING };

--- a/src/tournament.ts
+++ b/src/tournament.ts
@@ -1,326 +1,461 @@
+import { FIDE_SCORING } from './scoring.js';
+
 import type {
   AccelerationMethod,
+  Bye,
+  CompletedRound,
   Game,
-  GameKind,
-  PairingResult,
+  Pairing,
   PairingSystem,
+  Pairings,
   Player,
-  Result,
+  PointAdjustment,
+  Round,
+  ScoringSystem,
   Standing,
   Tiebreak,
-  TournamentOptions,
-  TournamentSnapshot,
+  TournamentData,
 } from './types.js';
+
+/** Hardcoded FIDE defaults for scoring fallback chains. */
+const DEFAULT_WIN = 1;
+const DEFAULT_DRAW = 0.5;
+const DEFAULT_LOSS = 0;
+const DEFAULT_FORFEIT_WIN = 1;
+const DEFAULT_FORFEIT_LOSS = 0;
+const DEFAULT_FULL_BYE = 1;
+const DEFAULT_HALF_BYE = 0.5;
+const DEFAULT_PAIRING_BYE = 1;
+const DEFAULT_ZERO_BYE = 0;
+
+/**
+ * Returns the score for a single game from the perspective of the given color.
+ */
+function scoreForGame(
+  game: Game,
+  color: 'black' | 'white',
+  scoring: ScoringSystem,
+): number {
+  const hasForfeit = 'forfeit' in game && game.forfeit !== undefined;
+
+  if (hasForfeit) {
+    if (game.result === 'none') {
+      return scoring.forfeitLoss ?? DEFAULT_FORFEIT_LOSS;
+    }
+    if (game.result === color) {
+      return scoring.forfeitWin ?? DEFAULT_FORFEIT_WIN;
+    }
+    return scoring.forfeitLoss ?? DEFAULT_FORFEIT_LOSS;
+  }
+
+  if (game.result === 'draw') {
+    if (color === 'white') {
+      return scoring.whiteDraw ?? scoring.draw ?? DEFAULT_DRAW;
+    }
+    return scoring.blackDraw ?? scoring.draw ?? DEFAULT_DRAW;
+  }
+
+  if (game.result === color) {
+    if (color === 'white') {
+      return scoring.whiteWin ?? scoring.win ?? DEFAULT_WIN;
+    }
+    return scoring.blackWin ?? scoring.win ?? DEFAULT_WIN;
+  }
+
+  // loss
+  if (color === 'white') {
+    return scoring.whiteLoss ?? scoring.loss ?? DEFAULT_LOSS;
+  }
+  return scoring.blackLoss ?? scoring.loss ?? DEFAULT_LOSS;
+}
+
+/**
+ * Returns the score for a bye based on its kind and the scoring system.
+ */
+function scoreForBye(bye: Bye, scoring: ScoringSystem): number {
+  switch (bye.kind) {
+    case 'full': {
+      return scoring.fullPointBye ?? DEFAULT_FULL_BYE;
+    }
+    case 'half': {
+      return scoring.halfPointBye ?? DEFAULT_HALF_BYE;
+    }
+    case 'pairing': {
+      return scoring.pairingAllocatedBye ?? DEFAULT_PAIRING_BYE;
+    }
+    case 'zero': {
+      return scoring.zeroPointBye ?? DEFAULT_ZERO_BYE;
+    }
+  }
+}
+
+/**
+ * Checks if a pairing entry is a completed game (has a result string).
+ */
+function isGame(entry: Game | Pairing): entry is Game {
+  return 'result' in entry && typeof (entry as Game).result === 'string';
+}
 
 /**
  * Stateful chess tournament orchestrator. Drives any pairing system through a
  * common lifecycle: create, pair, record results, standings, repeat.
  *
- * The pairing system is injected as a function parameter — the consumer
- * provides it from `@echecs/swiss`, `@echecs/round-robin`, or a custom
- * implementation.
+ * Follows the `PositionData` / `Position` pattern: `TournamentData` is the
+ * plain data interface, `Tournament` is the class that wraps it.
  *
  * @example
  * ```typescript
  * import { Tournament } from '@echecs/tournament';
  * import { dutch } from '@echecs/swiss';
  *
- * const t = new Tournament({
- *   pairingSystem: dutch,
- *   players: [{ id: 'alice' }, { id: 'bob' }, { id: 'carol' }, { id: 'dave' }],
- *   rounds: 3,
- * });
+ * const t = new Tournament(
+ *   {
+ *     completedRounds: [],
+ *     players: [
+ *       { id: 'alice', points: 0, rank: 1 },
+ *       { id: 'bob', points: 0, rank: 2 },
+ *       { id: 'carol', points: 0, rank: 3 },
+ *       { id: 'dave', points: 0, rank: 4 },
+ *     ],
+ *     totalRounds: 3,
+ *   },
+ *   { pairingSystem: dutch },
+ * );
  *
- * const r1 = t.pairRound();
- * for (const p of r1.pairings) {
- *   t.recordResult({ black: p.black, result: 1, white: p.white });
- * }
+ * const r1 = t.pair();
+ * // record results...
  * const standings = t.standings();
  * ```
  */
 class Tournament {
-  readonly #acceleration?: AccelerationMethod;
-  #currentRound = 0;
-  #games: Game[][] = [];
+  #completedRounds: CompletedRound[];
+  #currentRound?: Round;
+  #data: TournamentData;
   readonly #pairingSystem: PairingSystem;
-  readonly #players: Player[];
-  #roundPairings = new Map<number, PairingResult>();
-  readonly #rounds: number;
-  readonly #tiebreaks: string[];
 
   /**
    * Creates a new tournament.
    *
-   * @param options - Tournament configuration.
-   * @throws {RangeError} If fewer than 2 players or fewer than 1 round.
+   * @param data - Tournament data.
+   * @param options - Pairing system and optional acceleration method.
    */
-  constructor(options: TournamentOptions) {
-    if (options.players.length < 2) {
-      throw new RangeError('at least 2 players are required');
-    }
-    if (options.rounds < 1) {
-      throw new RangeError('at least 1 round is required');
-    }
-    this.#acceleration = options.acceleration;
+  constructor(
+    data: TournamentData,
+    options: {
+      acceleration?: AccelerationMethod;
+      pairingSystem: PairingSystem;
+    },
+  ) {
+    this.#completedRounds = data.completedRounds.map((r) => ({
+      ...r,
+      games: [...r.games],
+    }));
+    this.#currentRound = data.currentRound
+      ? { ...data.currentRound, games: [...data.currentRound.games] }
+      : undefined;
+    this.#data = { ...data };
     this.#pairingSystem = options.pairingSystem;
-    this.#players = [...options.players];
-    this.#rounds = options.rounds;
-    this.#tiebreaks = options.tiebreaks ? [...options.tiebreaks] : [];
   }
 
-  /** The current round number (1-based), or 0 if no round has been paired yet. */
-  get currentRound(): number {
-    return this.#currentRound;
-  }
-
-  /** All recorded games, grouped by round. Returns a defensive copy. */
-  get games(): readonly (readonly Game[])[] {
-    return this.#games.map((r) => [...r]);
-  }
-
-  /** Whether all rounds have been paired and all results recorded. */
-  get isComplete(): boolean {
-    return (
-      this.#currentRound >= this.#rounds &&
-      this.#isRoundComplete(this.#currentRound)
-    );
-  }
-
-  /** All tournament participants. Returns a defensive copy. */
-  get players(): readonly Player[] {
-    return [...this.#players];
-  }
-
-  /** Total number of rounds in the tournament. */
-  get rounds(): number {
-    return this.#rounds;
-  }
-
-  /** Ordered list of tiebreak identifiers. Returns a defensive copy. */
-  get tiebreaks(): readonly string[] {
-    return [...this.#tiebreaks];
-  }
-
-  #buildVirtualGames(round: number): Game[] {
-    if (!this.#acceleration) {
-      return [];
+  #addComment(comment: string): void {
+    if (!this.#data.metadata) {
+      this.#data.metadata = {};
     }
-    const virtualGames: Game[] = [];
-    for (const player of this.#players) {
-      const vp = this.#acceleration.virtualPoints(player, round, this.#rounds);
-      if (vp > 0) {
-        virtualGames.push({
-          black: player.id,
-          result: vp as Result,
-          white: player.id,
-        });
-      }
+    if (!this.#data.metadata.comments) {
+      this.#data.metadata.comments = [];
     }
-    return virtualGames;
+    this.#data.metadata.comments.push(comment);
   }
 
-  #findGame(
-    round: number,
+  #findGameIndex(
+    games: readonly (Game | Pairing)[],
     white: string,
     black: string,
-  ): { index: number; roundGames: Game[] } {
-    if (round < 1 || round > this.#currentRound) {
-      throw new RangeError('invalid round number');
-    }
-
-    const roundGames = this.#games[round - 1];
-    if (!roundGames || roundGames.length === 0) {
-      throw new RangeError(`no results recorded for round ${round}`);
-    }
-
-    const index = roundGames.findIndex(
+  ): number {
+    return games.findIndex(
       (g) =>
         (g.white === white && g.black === black) ||
         (g.white === black && g.black === white),
     );
-    if (index === -1) {
-      throw new RangeError(
-        `no result found for ${white} vs ${black} in round ${round}`,
-      );
-    }
-
-    return { index, roundGames };
-  }
-
-  #isRoundComplete(round: number): boolean {
-    const pairings = this.#roundPairings.get(round);
-    if (!pairings) {
-      return false;
-    }
-    return (this.#games[round - 1]?.length ?? 0) >= pairings.pairings.length;
-  }
-
-  #validateKind(kind: GameKind | undefined, result: Result): void {
-    if (kind === undefined) {
-      return;
-    }
-
-    const expectedResults: Record<GameKind, Result> = {
-      'forfeit-loss': 0,
-      'forfeit-win': 1,
-      'full-bye': 1,
-      'half-bye': 0.5,
-      'pairing-bye': 1,
-      'zero-bye': 0,
-    };
-
-    const expected = expectedResults[kind];
-    if (result !== expected) {
-      throw new RangeError(
-        `result ${result} is inconsistent with kind '${kind}'`,
-      );
-    }
   }
 
   /**
-   * Removes a previously recorded result from the specified round. The game is
-   * identified by the player pair (checked in both color orderings).
-   *
-   * After clearing, the round becomes incomplete and the pairing can be
-   * re-recorded via {@link recordResult}.
+   * Adds a point adjustment (penalty, bonus). Affects standings.
+   * Logs a comment in metadata.
+   */
+  adjust(adjustment: PointAdjustment): void {
+    if (!this.#data.adjustments) {
+      this.#data.adjustments = [];
+    }
+    this.#data.adjustments.push(adjustment);
+    this.#addComment(
+      `point adjustment: ${adjustment.points > 0 ? '+' : ''}${adjustment.points} for ${adjustment.playerId}${adjustment.reason ? ` (${adjustment.reason})` : ''}`,
+    );
+  }
+
+  /**
+   * Removes a result, reverting a game back to a pairing.
    *
    * @param round - The 1-based round number.
-   * @param white - One of the two player identifiers.
-   * @param black - The other player identifier.
-   * @throws {RangeError} If the round is invalid or no matching result exists.
+   * @param white - Player identifier for white.
+   * @param black - Player identifier for black.
+   * @throws {RangeError} If the round is invalid or no matching game exists.
    */
-  clearResult(round: number, white: string, black: string): void {
-    const { index, roundGames } = this.#findGame(round, white, black);
-    roundGames.splice(index, 1);
+  clear(round: number, white: string, black: string): void {
+    if (round < 1) {
+      throw new RangeError('invalid round number');
+    }
+
+    // Current round
+    if (this.#currentRound && round === this.#completedRounds.length + 1) {
+      const index = this.#findGameIndex(this.#currentRound.games, white, black);
+      const entry = index >= 0 ? this.#currentRound.games[index] : undefined;
+      if (index === -1 || !entry || !isGame(entry)) {
+        throw new RangeError(
+          `no game found for ${white} vs ${black} in round ${round}`,
+        );
+      }
+      this.#currentRound.games[index] = {
+        black: entry.black,
+        white: entry.white,
+      };
+      return;
+    }
+
+    // Completed round
+    const completedRound = this.#completedRounds[round - 1];
+    if (!completedRound) {
+      throw new RangeError('invalid round number');
+    }
+    const index = this.#findGameIndex(completedRound.games, white, black);
+    const existing = index >= 0 ? completedRound.games[index] : undefined;
+    if (index === -1 || !existing) {
+      throw new RangeError(
+        `no game found for ${white} vs ${black} in round ${round}`,
+      );
+    }
+    completedRound.games[index] = {
+      black: existing.black,
+      white: existing.white,
+    } as Game;
+  }
+
+  /**
+   * Corrects a result in any round (including completed). Logs a comment.
+   * Handles adjourned games (FIDE C.04.2 Art 3.1).
+   *
+   * @param round - The 1-based round number.
+   * @param game - The corrected game result.
+   * @throws {RangeError} If the round is invalid or no matching pairing exists.
+   */
+  correct(round: number, game: Game): void {
+    if (round < 1) {
+      throw new RangeError('invalid round number');
+    }
+
+    // Current round
+    if (this.#currentRound && round === this.#completedRounds.length + 1) {
+      const index = this.#findGameIndex(
+        this.#currentRound.games,
+        game.white,
+        game.black,
+      );
+      const existing = index >= 0 ? this.#currentRound.games[index] : undefined;
+      if (index === -1 || !existing) {
+        throw new RangeError(
+          `no pairing found for ${game.white} vs ${game.black} in round ${round}`,
+        );
+      }
+      this.#currentRound.games[index] = {
+        ...game,
+        black: existing.black,
+        white: existing.white,
+      };
+      this.#addComment(
+        `result correction in round ${round}: ${game.white} vs ${game.black}`,
+      );
+      return;
+    }
+
+    // Completed round
+    const completedRound = this.#completedRounds[round - 1];
+    if (!completedRound) {
+      throw new RangeError('invalid round number');
+    }
+    const index = this.#findGameIndex(
+      completedRound.games,
+      game.white,
+      game.black,
+    );
+    const existing = index >= 0 ? completedRound.games[index] : undefined;
+    if (index === -1 || !existing) {
+      throw new RangeError(
+        `no game found for ${game.white} vs ${game.black} in round ${round}`,
+      );
+    }
+    completedRound.games[index] = {
+      ...game,
+      black: existing.black,
+      white: existing.white,
+    };
+    this.#addComment(
+      `result correction in round ${round}: ${game.white} vs ${game.black}`,
+    );
+  }
+
+  /**
+   * Late entry (FIDE C.04.2 Art 2.4). Player joins with their specified
+   * points for missed rounds, paired from next `pair()` call.
+   */
+  enter(player: Player): void {
+    const existing = this.#data.players.find((p) => p.id === player.id);
+    if (existing) {
+      throw new RangeError(`player ${player.id} already registered`);
+    }
+    this.#data.players.push(player);
+    this.#addComment(`late entry: ${player.id}`);
   }
 
   /**
    * Restores a tournament from a serialized snapshot. The pairing system
    * function must be re-provided since functions are not JSON-serializable.
-   *
-   * @param snapshot - A snapshot previously returned by {@link toJSON}.
-   * @param pairingSystem - The pairing function to use for future rounds.
-   * @param acceleration - Optional acceleration method.
-   * @returns A restored Tournament instance.
    */
   static fromJSON(
-    snapshot: TournamentSnapshot,
-    pairingSystem: PairingSystem,
-    acceleration?: AccelerationMethod,
+    data: TournamentData,
+    options: {
+      acceleration?: AccelerationMethod;
+      pairingSystem: PairingSystem;
+    },
   ): Tournament {
-    const tournament = new Tournament({
-      acceleration,
-      pairingSystem,
-      players: snapshot.players,
-      rounds: snapshot.rounds,
-      tiebreaks: snapshot.tiebreaks,
-    });
-    tournament.#currentRound = snapshot.currentRound;
-    tournament.#games = snapshot.games.map((r) => [...r]);
-    for (const [round, pairings] of Object.entries(snapshot.roundPairings)) {
-      tournament.#roundPairings.set(Number(round), pairings);
-    }
-    return tournament;
+    return new Tournament(data, options);
   }
 
   /**
    * Generates pairings for the next round using the injected pairing system.
    *
    * @returns The pairings and byes for the new round.
-   * @throws {RangeError} If the tournament is complete or the current round has
-   *   unrecorded results.
+   * @throws {RangeError} If the tournament is complete or the current round
+   *   has unrecorded results.
    */
-  pairRound(): PairingResult {
-    if (this.#currentRound >= this.#rounds) {
+  pair(): Pairings {
+    if (this.#completedRounds.length >= this.#data.totalRounds) {
       throw new RangeError('tournament is complete');
     }
-    if (this.#currentRound > 0 && !this.#isRoundComplete(this.#currentRound)) {
-      throw new RangeError(
-        `round ${this.#currentRound} has unrecorded results`,
-      );
+    if (this.#currentRound) {
+      throw new RangeError('current round has unrecorded results');
     }
 
-    this.#currentRound++;
+    const result = this.#pairingSystem(
+      this.#data.players,
+      this.#completedRounds,
+    );
 
-    let games: Game[][] = [...this.#games];
-    if (this.#acceleration) {
-      const virtualGames = this.#buildVirtualGames(this.#currentRound);
-      games = [virtualGames, ...games];
-    }
+    this.#currentRound = {
+      byes: result.byes,
+      games: result.games.map((p) => ({ black: p.black, white: p.white })),
+    };
 
-    const result = this.#pairingSystem(this.#players, games);
-    this.#roundPairings.set(this.#currentRound, result);
-    this.#games.push([]);
     return result;
   }
 
   /**
-   * Records a game result for the current round.
-   *
-   * When `kind` is provided, the `result` must be consistent with it (e.g.
-   * `forfeit-win` requires `result: 1`).
+   * Records a result for a pairing in the current round. Validates the
+   * pairing exists. When all pairings have results, the round auto-completes.
    *
    * @param game - The game result to record.
-   * @throws {RangeError} If no round has been paired, the players don't match
-   *   any pairing, or `kind` and `result` are inconsistent.
+   * @throws {RangeError} If no round has been paired or the players don't
+   *   match any pairing.
    */
-  recordResult(game: {
-    black: string;
-    kind?: GameKind;
-    result: Result;
-    white: string;
-  }): void {
-    if (this.#currentRound === 0) {
+  record(game: Game): void {
+    if (!this.#currentRound) {
       throw new RangeError('no round has been paired yet');
     }
 
-    const roundPairings = this.#roundPairings.get(this.#currentRound);
-    if (!roundPairings) {
-      throw new RangeError('no pairings for current round');
-    }
-
-    const validPairing = roundPairings.pairings.some(
-      (p) =>
-        (p.white === game.white && p.black === game.black) ||
-        (p.white === game.black && p.black === game.white),
+    const index = this.#findGameIndex(
+      this.#currentRound.games,
+      game.white,
+      game.black,
     );
-    if (!validPairing) {
+    const existing = index >= 0 ? this.#currentRound.games[index] : undefined;
+    if (index === -1 || !existing) {
       throw new RangeError(
         `no pairing found for ${game.white} vs ${game.black}`,
       );
     }
 
-    this.#validateKind(game.kind, game.result);
+    this.#currentRound.games[index] = {
+      ...game,
+      black: existing.black,
+      white: existing.white,
+    };
 
-    const currentRoundGames = this.#games[this.#currentRound - 1];
-    if (currentRoundGames) {
-      currentRoundGames.push(game);
+    // Auto-complete the round if all pairings have results
+    if (this.#currentRound.games.every((entry) => isGame(entry))) {
+      this.#completedRounds.push({
+        byes: this.#currentRound.byes,
+        games: this.#currentRound.games as Game[],
+      });
+      this.#currentRound = undefined;
     }
   }
 
   /**
    * Returns players ranked by score descending, with optional tiebreaks
-   * applied in order. Tied players (same score and all tiebreak values)
-   * share the same rank.
+   * applied in order. Scoring uses the tournament's ScoringSystem.
    *
-   * @param tiebreaks - Ordered array of tiebreak functions. Each receives
-   *   `(playerId, games, players)` and returns a number. Higher values rank
-   *   higher.
+   * @param tiebreaks - Ordered array of tiebreak functions.
    * @returns Sorted standings array.
    */
   standings(tiebreaks: Tiebreak[] = []): Standing[] {
-    const results = this.#players.map((player) => {
+    const scoring = this.#data.scoringSystem ?? FIDE_SCORING;
+    const adjustments = this.#data.adjustments ?? [];
+
+    const results = this.#data.players.map((player) => {
       let score = 0;
-      for (const g of this.#games.flat()) {
-        if (g.white === player.id) {
-          score += g.result;
-        } else if (g.black === player.id) {
-          score += 1 - g.result;
+
+      // Score from completed rounds
+      for (const round of this.#completedRounds) {
+        for (const game of round.games) {
+          if (game.white === player.id) {
+            score += scoreForGame(game, 'white', scoring);
+          } else if (game.black === player.id) {
+            score += scoreForGame(game, 'black', scoring);
+          }
+        }
+        for (const bye of round.byes) {
+          if (bye.player === player.id) {
+            score += scoreForBye(bye, scoring);
+          }
+        }
+      }
+
+      // Score from current round (games that are completed)
+      if (this.#currentRound) {
+        for (const entry of this.#currentRound.games) {
+          if (isGame(entry)) {
+            if (entry.white === player.id) {
+              score += scoreForGame(entry, 'white', scoring);
+            } else if (entry.black === player.id) {
+              score += scoreForGame(entry, 'black', scoring);
+            }
+          }
+        }
+        for (const bye of this.#currentRound.byes) {
+          if (bye.player === player.id) {
+            score += scoreForBye(bye, scoring);
+          }
+        }
+      }
+
+      // Adjustments
+      for (const adj of adjustments) {
+        if (adj.playerId === player.id) {
+          score += adj.points;
         }
       }
 
       const tiebreakValues = tiebreaks.map((tb) =>
-        tb(player.id, this.#games, this.#players),
+        tb(player.id, this.#completedRounds, this.#data.players),
       );
 
       return {
@@ -368,55 +503,33 @@ class Tournament {
   /**
    * Serializes the tournament state to a plain object suitable for
    * `JSON.stringify`.
-   *
-   * @returns A serializable snapshot of the tournament.
    */
-  toJSON(): TournamentSnapshot {
-    const roundPairings: Record<string, PairingResult> = {};
-    for (const [round, pairings] of this.#roundPairings) {
-      roundPairings[String(round)] = pairings;
-    }
+  toJSON(): TournamentData {
     return {
-      currentRound: this.#currentRound,
-      games: this.#games.map((r) => [...r]),
-      players: [...this.#players],
-      roundPairings,
-      rounds: this.#rounds,
-      ...(this.#tiebreaks.length > 0 && { tiebreaks: [...this.#tiebreaks] }),
+      ...this.#data,
+      completedRounds: this.#completedRounds.map((r) => ({
+        ...r,
+        games: [...r.games],
+      })),
+      ...(this.#currentRound && {
+        currentRound: {
+          ...this.#currentRound,
+          games: [...this.#currentRound.games],
+        },
+      }),
+      players: [...this.#data.players],
     };
   }
 
   /**
-   * Replaces an existing result in any round. The game is identified by the
-   * `white`/`black` player pair (checked in both orderings). The stored game
-   * retains its original color assignment.
-   *
-   * @param round - The 1-based round number.
-   * @param game - The updated game data.
-   * @throws {RangeError} If the round is invalid, no matching result exists,
-   *   or `kind` and `result` are inconsistent.
+   * Player leaves. No longer paired (FIDE C.04.2 Art 3.2).
    */
-  updateResult(
-    round: number,
-    game: {
-      black: string;
-      kind?: GameKind;
-      result: Result;
-      white: string;
-    },
-  ): void {
-    this.#validateKind(game.kind, game.result);
-    const { index, roundGames } = this.#findGame(round, game.white, game.black);
-
-    const existing = roundGames[index];
-    if (existing) {
-      roundGames[index] = {
-        black: existing.black,
-        kind: game.kind,
-        result: game.result,
-        white: existing.white,
-      };
+  withdraw(playerId: string): void {
+    const index = this.#data.players.findIndex((p) => p.id === playerId);
+    if (index === -1) {
+      throw new RangeError(`player ${playerId} not found`);
     }
+    this.#data.players.splice(index, 1);
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,27 +1,4 @@
 /**
- * Classifies unplayed or special game results per FIDE C.07 Article 16.2.
- *
- * | Kind           | Result | FIDE ref    |
- * | -------------- | ------ | ----------- |
- * | `forfeit-win`  | `1`    | Art. 16.2.2 |
- * | `forfeit-loss` | `0`    | Art. 16.2.4 |
- * | `full-bye`     | `1`    | —           |
- * | `half-bye`     | `0.5`  | Art. 16.2.5 |
- * | `pairing-bye`  | `1`    | Art. 16.2.1 |
- * | `zero-bye`     | `0`    | Art. 16.2.3 |
- */
-type GameKind =
-  | 'forfeit-loss'
-  | 'forfeit-win'
-  | 'full-bye'
-  | 'half-bye'
-  | 'pairing-bye'
-  | 'zero-bye';
-
-/** Game result from white's perspective: `1` = white wins, `0.5` = draw, `0` = black wins. */
-type Result = 0 | 0.5 | 1;
-
-/**
  * An acceleration method that adds virtual points to certain players' scores
  * in early rounds, influencing the pairing system without affecting stored
  * results or standings.
@@ -31,22 +8,50 @@ interface AccelerationMethod {
   virtualPoints: (player: Player, round: number, totalRounds: number) => number;
 }
 
+/** Accelerated rounds configuration for a group of players. */
+interface AcceleratedRound {
+  firstPlayerId: string;
+  firstRound: number;
+  gamePoints: number;
+  lastPlayerId: string;
+  lastRound: number;
+  matchPoints: number;
+}
+
 /** A player who receives a bye (no opponent) for a round. */
 interface Bye {
+  /** Bye classification. */
+  kind: 'full' | 'half' | 'pairing' | 'zero';
   /** Player identifier. */
   player: string;
 }
 
-/** A recorded game between two players. */
-interface Game {
-  /** Player identifier for black. */
-  black: string;
-  /** Optional classification of the game type. When set, must be consistent with {@link Result}. */
-  kind?: GameKind;
-  /** Result from white's perspective. */
-  result: Result;
-  /** Player identifier for white. */
-  white: string;
+/** A completed round where all pairings have results. */
+interface CompletedRound extends Pairings {
+  games: Game[];
+}
+
+/**
+ * A recorded game between two players.
+ *
+ * Strict discriminated union: invalid combinations like
+ * `{ forfeit: 'both', result: 'white' }` won't typecheck.
+ * `rated` only applies to played games (no forfeit).
+ */
+type Game = Pairing &
+  (
+    | { forfeit: 'black'; rated?: never; result: 'white' }
+    | { forfeit: 'both'; rated?: never; result: 'none' }
+    | { forfeit: 'white'; rated?: never; result: 'black' }
+    | { forfeit?: never; rated?: boolean; result: 'black' | 'draw' | 'white' }
+  );
+
+/** A national rating record for a player. */
+interface NationalRating {
+  classification?: string;
+  federation: string;
+  nationalId?: string;
+  rating: number;
 }
 
 /** A pairing of two players for a round. */
@@ -58,19 +63,82 @@ interface Pairing {
 }
 
 /** The output of a pairing system for a single round. */
-interface PairingResult {
+interface Pairings {
   /** Players who receive a bye this round. */
   byes: Bye[];
-  /** Pairings for this round. */
-  pairings: Pairing[];
+  /** Pairings (or games) for this round. */
+  games: Pairing[];
+}
+
+/** Per-player acceleration overrides. */
+interface PlayerAcceleration {
+  playerId: string;
+  points: number[];
 }
 
 /** A tournament participant. */
 interface Player {
+  birthDate?: string;
+  federation?: string;
+  fideId?: string;
   /** Unique identifier for the player. */
   id: string;
+  name?: string;
+  nationalRatings?: NationalRating[];
+  /** Cumulative score across all recorded games. */
+  points: number;
+  /** 1-based rank. */
+  rank: number;
   /** Optional Elo rating. */
   rating?: number;
+  sex?: 'm' | 'w';
+  startingRank?: number;
+  title?: 'CM' | 'FM' | 'GM' | 'IM' | 'WCM' | 'WFM' | 'WGM' | 'WIM';
+}
+
+/** Player-level score adjustment (penalty, bonus, arbiter override). */
+interface PointAdjustment {
+  playerId: string;
+  points: number;
+  reason?: string;
+  /** Round this adjustment applies to. 0 = all rounds. */
+  round: number;
+}
+
+/** Prevents certain players from being paired against each other. */
+interface ProhibitedPairing {
+  firstRound: number;
+  lastRound: number;
+  playerIds: string[];
+}
+
+/** A round in progress where some pairings may have results. */
+interface Round extends Pairings {
+  games: (Game | Pairing)[];
+}
+
+/**
+ * Scoring system configuration. Color-specific values fall back to base,
+ * base falls back to FIDE defaults.
+ */
+interface ScoringSystem {
+  absence?: number;
+  blackDraw?: number;
+  blackLoss?: number;
+  blackWin?: number;
+  draw?: number;
+  forfeitLoss?: number;
+  forfeitWin?: number;
+  fullPointBye?: number;
+  halfPointBye?: number;
+  loss?: number;
+  pairingAllocatedBye?: number;
+  unknown?: number;
+  whiteDraw?: number;
+  whiteLoss?: number;
+  whiteWin?: number;
+  win?: number;
+  zeroPointBye?: number;
 }
 
 /** A player's position in the standings table. */
@@ -85,68 +153,92 @@ interface Standing {
   tiebreaks: number[];
 }
 
-/** Options for creating a new {@link Tournament}. */
-interface TournamentOptions {
-  /** Optional acceleration method (e.g. {@link bakuAcceleration}). */
-  acceleration?: AccelerationMethod;
-  /** The pairing function to use each round. */
-  pairingSystem: PairingSystem;
-  /** All tournament participants. Must contain at least 2 players. */
-  players: Player[];
-  /** Total number of rounds. Must be at least 1. */
-  rounds: number;
-  /** Optional ordered list of tiebreak identifiers. Opaque strings preserved through serialization. */
-  tiebreaks?: string[];
+/** A team of players. */
+interface Team {
+  gamePoints: number;
+  id: string;
+  matchPoints: number;
+  name: string;
+  nickname?: string;
+  playerIds: string[];
+  rank: number;
 }
 
-/** Serializable snapshot of a tournament's state, returned by {@link Tournament.toJSON}. */
-interface TournamentSnapshot {
-  /** The current round number (1-based), or 0 if no round has been paired. */
-  currentRound: number;
-  /** All recorded games, grouped by round. */
-  games: Game[][];
-  /** All tournament participants. */
+/** Tournament metadata — report information passed through untouched. */
+interface TournamentMetadata {
+  chiefArbiter?: string;
+  city?: string;
+  comments?: string[];
+  deputyArbiters?: string[];
+  endDate?: string;
+  federation?: string;
+  name?: string;
+  pairingController?: string;
+  roundDates?: string[];
+  startDate?: string;
+  timeControl?: string;
+  tournamentType?: string;
+}
+
+/**
+ * The plain data interface. What `toJSON()` returns and `fromJSON()` accepts.
+ * What `@echecs/trf`'s `parse()` returns and `stringify()` consumes.
+ */
+interface TournamentData {
+  acceleratedRounds?: AcceleratedRound[];
+  adjustments?: PointAdjustment[];
+  completedRounds: CompletedRound[];
+  currentRound?: Round;
+  metadata?: TournamentMetadata;
+  playerAccelerations?: PlayerAcceleration[];
   players: Player[];
-  /** Pairings for each round, keyed by round number as a string. */
-  roundPairings: Record<string, PairingResult>;
-  /** Total number of rounds. */
-  rounds: number;
-  /** Optional ordered list of tiebreak identifiers. */
+  prohibitedPairings?: ProhibitedPairing[];
+  scoringSystem?: ScoringSystem;
+  teams?: Team[];
   tiebreaks?: string[];
+  totalRounds: number;
 }
 
 /**
  * A function that generates pairings for a round given the player list and
- * game history. All pairing functions in `@echecs/swiss` and
- * `@echecs/round-robin` conform to this signature.
+ * completed rounds.
  */
-type PairingSystem = (players: Player[], games: Game[][]) => PairingResult;
+type PairingSystem = (players: Player[], rounds: CompletedRound[]) => Pairings;
 
 /**
  * A tiebreak function that computes a numeric value for a player based on the
- * game history. Higher values rank higher. Tiebreak functions from
- * `@echecs/buchholz`, `@echecs/sonneborn-berger`, etc. conform to this
- * signature.
+ * completed rounds. Higher values rank higher.
  *
  * @param player - The player identifier to compute the tiebreak for.
- * @param games - All recorded games, grouped by round.
+ * @param rounds - All completed rounds.
  * @param players - All tournament participants.
  * @returns A numeric tiebreak value.
  */
-type Tiebreak = (player: string, games: Game[][], players: Player[]) => number;
+type Tiebreak = (
+  player: string,
+  rounds: CompletedRound[],
+  players: Player[],
+) => number;
 
 export type {
   AccelerationMethod,
+  AcceleratedRound,
   Bye,
+  CompletedRound,
   Game,
-  GameKind,
+  NationalRating,
   Pairing,
-  PairingResult,
   PairingSystem,
+  Pairings,
   Player,
-  Result,
+  PlayerAcceleration,
+  PointAdjustment,
+  ProhibitedPairing,
+  Round,
+  ScoringSystem,
   Standing,
+  Team,
   Tiebreak,
-  TournamentOptions,
-  TournamentSnapshot,
+  TournamentData,
+  TournamentMetadata,
 };


### PR DESCRIPTION
## Summary

redesign the type system so `@echecs/tournament` becomes the shared type foundation for `@echecs/trf`, `@echecs/swiss`, and other consumers — no adapter layer.

- **`Game`** is now a strict discriminated union with string results (`'white'`/`'black'`/`'draw'`/`'none'`) and `forfeit`/`rated` fields. replaces `GameKind` + numeric `Result`.
- **`Bye`** requires `kind: 'full' | 'half' | 'pairing' | 'zero'` — byes are separate from games.
- **`Player`** widened with optional FIDE metadata (`fideId`, `title`, `federation`, `sex`, `birthDate`, `nationalRatings`, `startingRank`). requires `points` and `rank`.
- **rounds** modeled as `Pairings` -> `Round` -> `CompletedRound` progression. auto-completes when all results recorded.
- **`TournamentData`** replaces `TournamentOptions` + `TournamentSnapshot`. follows the `PositionData`/`Position` pattern from `@echecs/position`/`@echecs/fen`.
- **`ScoringSystem`** with all 17 fields and `FIDE_SCORING` constant exported. fallback chain: color-specific -> base -> FIDE default.
- **Tournament class** API: `pair()`, `record()`, `correct()`, `clear()`, `enter()`, `withdraw()`, `adjust()`, `standings()`, `toJSON()`, `fromJSON()`.
- **`PairingSystem`**: `(Player[], CompletedRound[]) -> Pairings`
- **`Tiebreak`**: `(string, CompletedRound[], Player[]) -> number`

### removed

`GameKind`, `Result`, `TournamentOptions`, `TournamentSnapshot`, `PairingResult`

closes #20
ref: echecsjs/trf#24