### PR TITLE
chore: release v3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,5 +78,5 @@
     "test:watch": "pnpm run test --watch"
   },
   "type": "module",
-  "version": "2.1.2"
+  "version": "3.0.0"
 }


### PR DESCRIPTION
bump version to 3.0.0 for the type widening breaking change (#33).