### PR TITLE
chore: release 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [3.1.0] - 2026-05-09
+
+### Added
+
+- read-only getters: `completedRounds`, `currentRound`, `isComplete`,
+  `metadata`, `players`, `totalRounds`
+
+### Removed
+
+- `fromJSON()` — use `new Tournament(data, options)` instead
+
 ## [3.0.0] - 2026-05-09
 
 ### Breaking Changes

--- a/package.json
+++ b/package.json
@@ -78,5 +78,5 @@
     "test:watch": "pnpm run test --watch"
   },
   "type": "module",
-  "version": "3.0.0"
+  "version": "3.1.0"
 }


### PR DESCRIPTION
version bump + changelog for 3.1.0.

- adds read-only getters (`completedRounds`, `currentRound`, `isComplete`, `metadata`, `players`, `totalRounds`)
- removes `fromJSON()` — use `new Tournament(data, options)` instead