### PR TITLE
chore: release 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.1.1] - 2026-05-15
+
+### Fixed
+
+- `pair()` now calls `onWarning` when a full-point bye is assigned, flagging it
+  as deprecated per FIDE rules (VCL.17)
+
 ## [3.1.0] - 2026-05-09
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -78,5 +78,5 @@
     "test:watch": "pnpm run test --watch"
   },
   "type": "module",
-  "version": "3.1.0"
+  "version": "3.1.1"
 }


### PR DESCRIPTION
## Summary

- bump version to 3.1.1
- add changelog entry for VCL.17 full-point bye deprecation warning