### PR TITLE
feat: add withdrawnPlayers to TournamentData and startingRankMethod to TournamentMetadata

### DIFF
--- a/src/__tests__/tournament.spec.ts
+++ b/src/__tests__/tournament.spec.ts
@@ -713,6 +713,47 @@ describe('Tournament', () => {
       });
       expect(() => t.withdraw('z')).toThrow(RangeError);
     });
+
+    it('persists withdrawnPlayers in toJSON()', () => {
+      const t = new Tournament(
+        makeData({
+          players: [
+            { id: 'a', points: 0, rank: 1 },
+            { id: 'b', points: 0, rank: 2 },
+            { id: 'c', points: 0, rank: 3 },
+            { id: 'd', points: 0, rank: 4 },
+          ],
+          totalRounds: 3,
+        }),
+        { pairingSystem: mockPairingSystem },
+      );
+      t.withdraw('d');
+      const json = t.toJSON();
+      expect(json.withdrawnPlayers).toEqual(['d']);
+    });
+
+    it('restores withdrawnPlayers from data', () => {
+      const t = new Tournament(
+        makeData({
+          players: [
+            { id: 'a', points: 0, rank: 1 },
+            { id: 'b', points: 0, rank: 2 },
+            { id: 'c', points: 0, rank: 3 },
+            { id: 'd', points: 0, rank: 4 },
+          ],
+          totalRounds: 3,
+          withdrawnPlayers: ['d'],
+        }),
+        { pairingSystem: mockPairingSystem },
+      );
+      // 'd' should be excluded from pairing
+      const r1 = t.pair();
+      const pairedIds = [
+        ...r1.games.flatMap((g) => [g.white, g.black]),
+        ...r1.byes.map((b) => b.player),
+      ];
+      expect(pairedIds).not.toContain('d');
+    });
   });
 
   describe('adjust()', () => {

--- a/src/tournament.ts
+++ b/src/tournament.ts
@@ -163,7 +163,7 @@ class Tournament {
     this.#onWarning = options.onWarning;
     this.#pairingSystem = options.pairingSystem;
 
-    this.#withdrawn = new Set<string>();
+    this.#withdrawn = new Set<string>(data.withdrawnPlayers);
 
     // Resolve tiebreak IDs to functions
     const tiebreakIds = data.tiebreaks ?? [];
@@ -608,6 +608,8 @@ class Tournament {
    * `JSON.stringify`.
    */
   toJSON(): TournamentData {
+    const withdrawn =
+      this.#withdrawn.size > 0 ? [...this.#withdrawn].toSorted() : undefined;
     return {
       ...this.#data,
       completedRounds: this.#completedRounds.map((r) => ({
@@ -621,6 +623,7 @@ class Tournament {
         },
       }),
       players: [...this.#data.players],
+      ...(withdrawn && { withdrawnPlayers: withdrawn }),
     };
   }
 
@@ -633,6 +636,7 @@ class Tournament {
       throw new RangeError(`player ${playerId} not found`);
     }
     this.#withdrawn.add(playerId);
+    this.#data.withdrawnPlayers = [...this.#withdrawn].toSorted();
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -176,6 +176,7 @@ interface TournamentMetadata {
   pairingController?: string;
   roundDates?: string[];
   startDate?: string;
+  startingRankMethod?: string;
   timeControl?: string;
   tournamentType?: string;
 }
@@ -197,6 +198,7 @@ interface TournamentData {
   teams?: Team[];
   tiebreaks?: string[];
   totalRounds: number;
+  withdrawnPlayers?: string[];
 }
 
 /**


### PR DESCRIPTION
adds `withdrawnPlayers?: string[]` to `TournamentData` and `startingRankMethod?: string` to `TournamentMetadata`.

- `Tournament` class constructor now respects `withdrawnPlayers` from input data (excludes them from pairing)
- `withdraw()` persists to `#data.withdrawnPlayers` so it survives `toJSON()` roundtrips
- `toJSON()` includes `withdrawnPlayers` when non-empty

part of the parser-to-tournament-data unification — `@echecs/trf` and `@echecs/tunx` will depend on these fields to map absent players and starting rank method from their respective formats.