### PR TITLE
release: @echecs/tournament@3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [3.2.0] - 2026-05-25
+
+### Added
+
+- `withdrawnPlayers?: string[]` on `TournamentData` — tracks players who left
+  the tournament, survives `toJSON()` roundtrips
+- `startingRankMethod?: string` on `TournamentMetadata` — records how the
+  initial ranking list was determined
+- `Tournament` constructor now respects `withdrawnPlayers` from input data
+  (excludes them from pairing)
+- `withdraw()` persists the player ID to `TournamentData.withdrawnPlayers`
+
 ## [3.1.1] - 2026-05-15
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -78,5 +78,5 @@
     "test:watch": "pnpm run test --watch"
   },
   "type": "module",
-  "version": "3.1.1"
+  "version": "3.2.0"
 }


### PR DESCRIPTION
minor release — adds `withdrawnPlayers` and `startingRankMethod` fields.