### PR TITLE
release: @echecs/tournament@3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [3.3.0] - 2026-05-27
+
+### Added
+
+- `PairingOptions` interface with `trace` and `expectedRounds` fields.
+- `TraceCallback` type for pairing algorithm observability.
+- `onTrace` option in `Tournament` constructor — forwarded to the pairing system
+  on each `pair()` call.
+- `expectedRounds` is now automatically forwarded from `totalRounds` to the
+  pairing system.
+
+### Changed
+
+- `PairingSystem` type now accepts an optional third `PairingOptions` parameter.
+
 ## [3.2.0] - 2026-05-25
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -78,5 +78,5 @@
     "test:watch": "pnpm run test --watch"
   },
   "type": "module",
-  "version": "3.2.0"
+  "version": "3.3.0"
 }

--- a/src/__tests__/tournament.spec.ts
+++ b/src/__tests__/tournament.spec.ts
@@ -69,6 +69,24 @@ const byePairingSystem: PairingSystem = (ps): Pairings => {
   return { byes, games };
 };
 
+const tracingPairingSystem: PairingSystem = (
+  players,
+  _rounds,
+  options,
+): Pairings => {
+  if (options?.trace) {
+    options.trace({ playerCount: players.length, type: 'test:event' });
+  }
+  const games: Pairing[] = [];
+  for (let index = 0; index < players.length - 1; index += 2) {
+    games.push({
+      black: players[index + 1]!.id,
+      white: players[index]!.id,
+    });
+  }
+  return { byes: [], games };
+};
+
 const fullByePairingSystem: PairingSystem = (ps): Pairings => {
   const games: Pairing[] = [];
   const byes: Bye[] = [];
@@ -963,6 +981,76 @@ describe('Tournament', () => {
       expect(FIDE_SCORING.pairingAllocatedBye).toBe(1);
       expect(FIDE_SCORING.zeroPointBye).toBe(0);
       expect(FIDE_SCORING.absence).toBe(0);
+    });
+  });
+
+  describe('trace', () => {
+    it('forwards onTrace to the pairing system', () => {
+      const events: Record<string, unknown>[] = [];
+
+      const t = new Tournament(makeData(), {
+        onTrace: (event) => events.push(event),
+        pairingSystem: tracingPairingSystem,
+      });
+      t.pair();
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toStrictEqual({
+        playerCount: 4,
+        type: 'test:event',
+      });
+    });
+
+    it('forwards expectedRounds from totalRounds', () => {
+      let received: number | undefined;
+      const inspectingSystem: PairingSystem = (
+        players,
+        _rounds,
+        options,
+      ): Pairings => {
+        received = options?.expectedRounds;
+        const games: Pairing[] = [];
+        for (let index = 0; index < players.length - 1; index += 2) {
+          games.push({
+            black: players[index + 1]!.id,
+            white: players[index]!.id,
+          });
+        }
+        return { byes: [], games };
+      };
+
+      const t = new Tournament(makeData({ totalRounds: 7 }), {
+        pairingSystem: inspectingSystem,
+      });
+      t.pair();
+
+      expect(received).toBe(7);
+    });
+
+    it('does not include trace key when onTrace is not provided', () => {
+      let receivedOptions: unknown;
+      const inspectingSystem: PairingSystem = (
+        players,
+        _rounds,
+        options,
+      ): Pairings => {
+        receivedOptions = options;
+        const games: Pairing[] = [];
+        for (let index = 0; index < players.length - 1; index += 2) {
+          games.push({
+            black: players[index + 1]!.id,
+            white: players[index]!.id,
+          });
+        }
+        return { byes: [], games };
+      };
+
+      const t = new Tournament(makeData(), {
+        pairingSystem: inspectingSystem,
+      });
+      t.pair();
+
+      expect(receivedOptions).toStrictEqual({ expectedRounds: 3 });
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export type {
   Game,
   NationalRating,
   Pairing,
+  PairingOptions,
   PairingSystem,
   Pairings,
   Player,
@@ -22,4 +23,5 @@ export type {
   Tiebreak,
   TournamentData,
   TournamentMetadata,
+  TraceCallback,
 } from './types.js';

--- a/src/tournament.ts
+++ b/src/tournament.ts
@@ -6,6 +6,7 @@ import type {
   CompletedRound,
   Game,
   Pairing,
+  PairingOptions,
   PairingSystem,
   Pairings,
   Player,
@@ -16,6 +17,7 @@ import type {
   Tiebreak,
   TournamentData,
   TournamentMetadata,
+  TraceCallback,
 } from './types.js';
 
 /** Hardcoded FIDE defaults for scoring fallback chains. */
@@ -132,6 +134,7 @@ class Tournament {
   #completedRounds: CompletedRound[];
   #currentRound?: Round;
   #data: TournamentData;
+  readonly #onTrace?: TraceCallback;
   readonly #onWarning?: (message: string) => void;
   readonly #pairingSystem: PairingSystem;
   readonly #tiebreakFns: Tiebreak[];
@@ -147,6 +150,7 @@ class Tournament {
     data: TournamentData,
     options: {
       acceleration?: AccelerationMethod;
+      onTrace?: TraceCallback;
       onWarning?: (message: string) => void;
       pairingSystem: PairingSystem;
       tiebreaks?: Record<string, Tiebreak>;
@@ -160,6 +164,7 @@ class Tournament {
       ? { ...data.currentRound, games: [...data.currentRound.games] }
       : undefined;
     this.#data = { ...data };
+    this.#onTrace = options.onTrace;
     this.#onWarning = options.onWarning;
     this.#pairingSystem = options.pairingSystem;
 
@@ -472,7 +477,15 @@ class Tournament {
     const activePlayers = this.#data.players.filter(
       (p) => !this.#withdrawn.has(p.id),
     );
-    const result = this.#pairingSystem(activePlayers, this.#completedRounds);
+    const pairingOptions: PairingOptions = {
+      expectedRounds: this.#data.totalRounds,
+      ...(this.#onTrace && { trace: this.#onTrace }),
+    };
+    const result = this.#pairingSystem(
+      activePlayers,
+      this.#completedRounds,
+      pairingOptions,
+    );
 
     this.#currentRound = {
       byes: result.byes,

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,16 @@ interface Pairing {
   white: string;
 }
 
+/**
+ * Options forwarded to the pairing system on each `pair()` call.
+ */
+interface PairingOptions {
+  /** Total expected rounds in the tournament. Affects last-round compatibility checks. */
+  expectedRounds?: number;
+  /** Structured trace callback for pairing algorithm observability. */
+  trace?: TraceCallback;
+}
+
 /** The output of a pairing system for a single round. */
 interface Pairings {
   /** Players who receive a bye this round. */
@@ -205,7 +215,18 @@ interface TournamentData {
  * A function that generates pairings for a round given the player list and
  * completed rounds.
  */
-type PairingSystem = (players: Player[], rounds: CompletedRound[]) => Pairings;
+type PairingSystem = (
+  players: Player[],
+  rounds: CompletedRound[],
+  options?: PairingOptions,
+) => Pairings;
+
+/**
+ * Callback for pairing algorithm trace events. The event shape is defined by
+ * each pairing system — tournament forwards the callback without inspecting
+ * the events.
+ */
+type TraceCallback = (event: Record<string, unknown>) => void;
 
 /**
  * A tiebreak function that computes a numeric value for a player based on the
@@ -230,6 +251,7 @@ export type {
   Game,
   NationalRating,
   Pairing,
+  PairingOptions,
   PairingSystem,
   Pairings,
   Player,
@@ -243,4 +265,5 @@ export type {
   Tiebreak,
   TournamentData,
   TournamentMetadata,
+  TraceCallback,
 };


### PR DESCRIPTION
- add `PairingOptions` interface with `trace` and `expectedRounds` fields
- add `TraceCallback` type for pairing algorithm observability
- add `onTrace` option in `Tournament` constructor — forwarded to the pairing system on each `pair()` call
- `expectedRounds` is now automatically forwarded from `totalRounds` to the pairing system
- `PairingSystem` type now accepts an optional third `PairingOptions` parameter